### PR TITLE
docs(import): add import react to all missing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ yarn add @consta/uikit
 Чтобы начать работу с библиотекой интерфейсных компонентов, подключите тему:
 
 ```tsx
+import React from 'react';
 import { Theme, presetGpnDefault } from '@consta/uikit/Theme';
 import { Button } from '@consta/uikit/Button';
 

--- a/docs/common/start.stories.mdx
+++ b/docs/common/start.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 Тему обязательно нужно подключать в корне приложения, так, чтобы все компоненты `@consta/uikit` были вложены в компонент `Theme`.
 
 ```tsx
+import React from 'react';
 import { Theme, presetGpnDefault } from '@consta/uikit/Theme';
 import { Button } from '@consta/uikit/Button';
 

--- a/docs/thematization/howToConnectTheme.stories.mdx
+++ b/docs/thematization/howToConnectTheme.stories.mdx
@@ -97,6 +97,7 @@ export const RootTheme: React.FC = () => {
 С помощью `useTheme` удобно переключать цветовую схему на акцентную или инвертную.
 
 ```tsx
+import React from 'react';
 import { useTheme } from '@consta/uikit/Theme';
 import { Text } from '@consta/uikit/Text';
 


### PR DESCRIPTION
closes #1547

Добавлено   `import React from 'react'` во все примеры где этого не было указано