### PR TITLE
fix(Select): fix width

### DIFF
--- a/src/components/SelectComponents/SelectDropdown/SelectDropdown.css
+++ b/src/components/SelectComponents/SelectDropdown/SelectDropdown.css
@@ -3,7 +3,6 @@
   z-index: 9999;
   overflow: hidden;
   box-sizing: border-box;
-  width: 100%;
   min-width: 220px;
   margin: -1px 0 -1px;
   background: var(--color-bg-default);


### PR DESCRIPTION
Remove width: 100% from Select dropdown

## Описание изменений

В основе списка используется Popover, в котором уже указывается ширина, по сему достаточно было просто удалить `width` из класса `.SelectDropdown`.

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
