### PR TITLE
feat(Combobox): hide label for not found while items list is empty

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       # Делаем checkout текущей ветки
       - uses: actions/checkout@master
+
+      - name: Print Info
+        run: echo "🎉 ${{secrets.DEPLOY_SERVER_HOST}} ${{secrets.DEPLOY_SERVER_HOST}} at http://${{env.BRANCH_NAME}}.${{env.APP_NAME}}.${{secrets.DEPLOY_DOMAIN}}"
+
       # Устанавливаем Node.JS для сборки приложения
       - uses: actions/setup-node@v1
         with:
@@ -64,6 +68,7 @@ jobs:
           strip_components: 1
           overwrite: true
           rm: true
+          passphrase: ''
       - name: Print Info
         run: echo "🎉 Deployed at http://${{env.BRANCH_NAME}}.${{env.APP_NAME}}.${{secrets.DEPLOY_DOMAIN}}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,6 @@ jobs:
     steps:
       # Делаем checkout текущей ветки
       - uses: actions/checkout@master
-
-      - name: Print Info
-        run: echo "🎉 ${{secrets.DEPLOY_SERVER_HOST}} ${{secrets.DEPLOY_SERVER_HOST}} at http://${{env.BRANCH_NAME}}.${{env.APP_NAME}}.${{secrets.DEPLOY_DOMAIN}}"
-
       # Устанавливаем Node.JS для сборки приложения
       - uses: actions/setup-node@v1
         with:
@@ -68,7 +64,6 @@ jobs:
           strip_components: 1
           overwrite: true
           rm: true
-          passphrase: ''
       - name: Print Info
         run: echo "🎉 Deployed at http://${{env.BRANCH_NAME}}.${{env.APP_NAME}}.${{secrets.DEPLOY_DOMAIN}}"
 

--- a/src/components/SelectComponents/SelectDropdown/SelectDropdown.tsx
+++ b/src/components/SelectComponents/SelectDropdown/SelectDropdown.tsx
@@ -148,7 +148,7 @@ export const SelectDropdown: SelectDropdown = (props) => {
                 </Fragment>
               );
             })}
-            {!isLoading && notFound && labelForNotFound && (
+            {!isLoading && hasItems && notFound && labelForNotFound && (
               <Text className={cnSelectDropdown('LabelForNotFound')}>{labelForNotFound}</Text>
             )}
             {!isLoading && !hasItems && labelForEmptyItems && (


### PR DESCRIPTION
## Описание изменений

Если в компонент `Combobox` приходит пустой список `items`, то при поиске элемента показывался и лэйбл "Не найдено" и "Список пуск".
Для такого случая убрал `labelForNotFound` в `SelectDropdown`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
