### PR TITLE
docs(Header): fix typo in doc 

### DIFF
--- a/src/components/Header/__stories__/Header.docs.mdx
+++ b/src/components/Header/__stories__/Header.docs.mdx
@@ -53,7 +53,7 @@ Header формируется из независимых модулей. Это
 - [меню](#меню) — `HeaderMenu`
 - [поиск](#поиск) — `HeaderSearchBar`
 - [кнопки](#кнопки) — `HeaderButton`
-- [логин](#логин) — `HederLogin`
+- [логин](#логин) — `HeaderLogin`
 
 Вы можете использовать все модули или только некоторые,
 можете добавить свои (но сначала прочитайте, [как это правильно сделать и оформить](?path=/docs/common-develop-contributors--page)).
@@ -77,7 +77,7 @@ Header состоит из левой и правой части — `leftSide` 
 В левую часть складываются модули
 [HeaderLogo](#headerlogo), [HeaderMenu](#headermenu) и [HeaderSearchBar](#headersearchbar).
 
-В правую — [HederLogin](#headerlogin). [HeaderButton](#headerbutton) можно ставить в любую часть.
+В правую — [HeaderLogin](#headerlogin). [HeaderButton](#headerbutton) можно ставить в любую часть.
 
 Ширина всех модулей равна ширине контента, если об этом отдельно не сказано.
 


### PR DESCRIPTION
closes #2168

## Описание изменений

Поправила опечтаку в документации: Heder —> Header
