### PR TITLE
Docs/grid

### DIFF
--- a/src/components/Grid/__stories__/Grid.docs.mdx
+++ b/src/components/Grid/__stories__/Grid.docs.mdx
@@ -271,6 +271,7 @@ export function GridExampleBreakpoints() {
 ```tsx
 <Grid cols="3" gap="xl">
   <GridItem
+    style={{ background: 'rgb(87, 188, 255)' }} // синяя ячейка
     row="1"
     breakpoints={{
       m: {
@@ -282,38 +283,7 @@ export function GridExampleBreakpoints() {
   </GridItem>
   <GridItem>2</GridItem>
   <GridItem
-    order="-1"
-    row="3"
-    breakpoints={{
-      m: {
-        order: 0,
-        row: 1,
-      },
-    }}
-  >
-    3
-  </GridItem>
-  <GridItem>4</GridItem>
-  <GridItem>5</GridItem>
-  <GridItem>6</GridItem>
-  <GridItem>7</GridItem>
-</Grid>
-
-<Grid cols="3" gap="xl">
-  <GridItem
-    style= {{ background: 'rgb(87, 188, 255)' }} // зелёная ячейка
-    row="1"
-    breakpoints={{
-      m: {
-        row: 3,
-      },
-    }}
-  >
-    1
-  </GridItem>
-  <GridItem>2</GridItem>
-  <GridItem
-    style={{ background:'#36acaa' }} // синяя ячейка
+    style={{ background: '#36acaa' }} // зелёная ячейка
     order="-1"
     row="3"
     breakpoints={{

--- a/src/components/Grid/__stories__/Grid.docs.mdx
+++ b/src/components/Grid/__stories__/Grid.docs.mdx
@@ -298,6 +298,38 @@ export function GridExampleBreakpoints() {
   <GridItem>6</GridItem>
   <GridItem>7</GridItem>
 </Grid>
+
+<Grid cols="3" gap="xl">
+  <GridItem
+    style= {{ background: 'rgb(87, 188, 255)' }} // зелёная ячейка
+    row="1"
+    breakpoints={{
+      m: {
+        row: 3,
+      },
+    }}
+  >
+    1
+  </GridItem>
+  <GridItem>2</GridItem>
+  <GridItem
+    style={{ background:'#36acaa' }} // синяя ячейка
+    order="-1"
+    row="3"
+    breakpoints={{
+      m: {
+        order: 0,
+        row: 1,
+      },
+    }}
+  >
+    3
+  </GridItem>
+  <GridItem>4</GridItem>
+  <GridItem>5</GridItem>
+  <GridItem>6</GridItem>
+  <GridItem>7</GridItem>
+</Grid>
 ```
 
 <GridItemExampleBreakpoints />


### PR DESCRIPTION
## Описание изменений

Поправила код примера: там когда вычищали стили, заоднго вычистили цвета, в которые красятся ячейки. Добавила прямо в код, если так некрасиво, можно сделать код примера со стилями и добавить в него CSS.