### PR TITLE
fix(Table): баг с закрытием коллапса в Table

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -724,7 +724,7 @@ const InternalTable = <T extends TableRow>(
     if (rows) {
       setExpandedRowIds(getExpandedRows(rows, defaultExpandAll));
     }
-  }, [rows, defaultExpandAll]);
+  }, [defaultExpandAll]);
 
   const renderCell = (
     column: TableColumn<T>,


### PR DESCRIPTION
при изменении rows(например там меняется текст в TextField) в коллапсы опять записывается defaultExpand, и он закрывается, поэтому убрал rows из зависимости useEffect

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
