### PR TITLE
fix(DatePicker): fixed validate mask

### DIFF
--- a/src/components/DatePicker/helpers.ts
+++ b/src/components/DatePicker/helpers.ts
@@ -75,7 +75,7 @@ export const getTimeEnum = (
 export const getFormForStart = (form: TextFieldPropForm) => getForm(form, 0, 2);
 export const getFormForEnd = (form: TextFieldPropForm) => getForm(form, 1, 2);
 
-const getPartDate = (
+export const getPartDate = (
   formatArray: string[],
   stringArray: string[],
   marker: string,


### PR DESCRIPTION
fix #2979

## Описание изменений

Нелзя было использовать формат без полного набора групп

К примеру:
рекомендуется `HH:mm:ss` и не возможно испорлзовать `HH:mm`
рекомендуется `dd:MM:yyyy` и не возможно испорлзовать `dd:MM`

Данный фикс исправляет эту проблему

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
