### PR TITLE
feat(Selects): add props for control dropdown open/close state

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bem-react/classname": "^1.5.12",
     "@bem-react/classnames": "^1.3.10",
-    "@consta/icons": "^0.5.2",
+    "@consta/icons": "^0.9.0",
     "compute-scroll-into-view": "^1.0.17",
     "date-fns": "^2.29.1",
     "focus-trap-react": "8.7.0",

--- a/src/components/AutoCompleteCanary/AutoCompleteCanary.tsx
+++ b/src/components/AutoCompleteCanary/AutoCompleteCanary.tsx
@@ -69,6 +69,9 @@ const AutoCompleteRender = <
     className,
     virtualScroll,
     onScrollToBottom,
+    onDropdownOpen,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
     ...otherProps
   } = withDefaultGetters(props);
 
@@ -119,6 +122,9 @@ const AutoCompleteRender = <
     onFocus,
     searchFunction,
     isLoading,
+    onDropdownOpen,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
   });
 
   const renderItemDefault: PropRenderItem<ITEM> = (props) => {
@@ -154,7 +160,8 @@ const AutoCompleteRender = <
         inputRef={useForkRef([inputRef, inputControlRef])}
         onBlur={handleInputBlur}
         inputContainerRef={useForkRef([containerRef, inputContainerRef])}
-        onFocus={handleInputFocus}
+        // onFocus={handleInputFocus}
+        onClick={handleInputFocus}
         onChange={handleInputChange}
         value={value}
         style={style}

--- a/src/components/AutoCompleteCanary/AutoCompleteCanary.tsx
+++ b/src/components/AutoCompleteCanary/AutoCompleteCanary.tsx
@@ -160,7 +160,6 @@ const AutoCompleteRender = <
         inputRef={useForkRef([inputRef, inputControlRef])}
         onBlur={handleInputBlur}
         inputContainerRef={useForkRef([containerRef, inputContainerRef])}
-        // onFocus={handleInputFocus}
         onClick={handleInputFocus}
         onChange={handleInputChange}
         value={value}

--- a/src/components/AutoCompleteCanary/__stand__/AutoComplete.dev.stand.mdx
+++ b/src/components/AutoCompleteCanary/__stand__/AutoComplete.dev.stand.mdx
@@ -16,6 +16,7 @@ import {
 } from './examples/AutoCompleteExampleType/AutoCompleteExampleType';
 import { AutoCompleteExampleView } from './examples/AutoCompleteExampleView/AutoCompleteExampleView';
 import { AutoCompleteExampleVirtualScroll } from './examples/AutoCompleteExampleVirtualScroll/AutoCompleteExampleVirtualScroll';
+import { AutoCompleteExampleDropdownOpen } from './examples/AutoCompleteExampleDropdownOpen/AutoCompleteExampleDropdownOpen';
 import {
   AutoCompleteExampleIsLoading,
   AutoCompleteExampleOnScrollBottom,
@@ -44,6 +45,7 @@ import { AutoComplete } from '@consta/uikit/AutoCompleteCanary';
 - [Виртуализация списка](#виртуализация-списка)
 - [Индикация загрузки](#индикация-загрузки)
 - [Неактивный выпадающий список](#неактивный-выпадающий-список)
+- [Управление состоянием выподающего списка](#управление-состоянием-выподающего-списка)
 - [Кастомизация](#кастомизация)
   - [Кастомный элемент списка](#кастомный-элемент-списка)
 - [Импорт](#импорт)
@@ -938,6 +940,16 @@ const AutoCompleteExampleDisabled = () => {
 ```
 
 <AutoCompleteExampleDisabled />
+
+## Управление состоянием выподающего списка
+
+Для управлением состояния выподающего списка используйте следующие свойства:
+
+- `dropdownOpen` - флаг открыт/закрыт
+- `onDropdownOpen` - колбек отрабатывающий каждый раз при открытии/закрытии
+- `ignoreClicksInsideRefs` - список ссылок на элементы по которым игнорируется клики
+
+<AutoCompleteExampleDropdownOpen />
 
 # Кастомизация
 

--- a/src/components/AutoCompleteCanary/__stand__/AutoComplete.dev.stand.mdx
+++ b/src/components/AutoCompleteCanary/__stand__/AutoComplete.dev.stand.mdx
@@ -66,7 +66,7 @@ import { AutoComplete } from '@consta/uikit/AutoCompleteCanary';
 Элементы выпадающего списка, то есть подсказки, можно описать в объекте `items` типа [DefaultItem](#свойства). Что внутри:
 
 - `label` — название элемента списка,
-- `id` — уникальный ключ элемента,
+- `id` — уникальный ключ элемента,
 - `groupId` — идентификатор [группы](#группы-подсказок), в которую входит этот элемент (если список разбит на группы).
 
 Вы можете создать [кастомный тип данных для подсказок](#кастомный-элемент-списка) и использовать его.
@@ -948,6 +948,83 @@ const AutoCompleteExampleDisabled = () => {
 - `dropdownOpen` - флаг открыт/закрыт
 - `onDropdownOpen` - колбек отрабатывающий каждый раз при открытии/закрытии
 - `ignoreClicksInsideRefs` - список ссылок на элементы по которым игнорируется клики
+
+```tsx
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const AutoCompleteExampleDropdownOpen = () => {
+  const [value, setValue] = useState<string | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <AutoComplete
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreOutsideClicksRefs={[buttonRef]}
+            searchFunction={(item, searchValue) => {
+              if (!searchValue) {
+                return true;
+              }
+              return (
+                item.label
+                  .toLocaleLowerCase()
+                  .indexOf(searchValue.toLocaleLowerCase()) !== -1
+              );
+            }}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};
+```
 
 <AutoCompleteExampleDropdownOpen />
 

--- a/src/components/AutoCompleteCanary/__stand__/examples/AutoCompleteExampleDropdownOpen/AutoCompleteExampleDropdownOpen.tsx
+++ b/src/components/AutoCompleteCanary/__stand__/examples/AutoCompleteExampleDropdownOpen/AutoCompleteExampleDropdownOpen.tsx
@@ -1,0 +1,86 @@
+import { AnimateIconSwitcherProvider } from '@consta/icons/AnimateIconSwitcherProvider';
+import { IconArrowDown } from '@consta/icons/IconArrowDown';
+import { withAnimateSwitcherHOC } from '@consta/icons/withAnimateSwitcherHOC';
+import { Example } from '@consta/stand';
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Button } from '##/components/Button';
+import { FieldGroup } from '##/components/FieldGroup';
+import { useFlag } from '##/hooks/useFlag';
+
+import { AutoComplete } from '../../..';
+
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const AutoCompleteExampleDropdownOpen = () => {
+  const [value, setValue] = useState<string | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <AutoComplete
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreOutsideClicksRefs={[buttonRef]}
+            searchFunction={(item, searchValue) => {
+              if (!searchValue) {
+                return true;
+              }
+              return (
+                item.label
+                  .toLocaleLowerCase()
+                  .indexOf(searchValue.toLocaleLowerCase()) !== -1
+              );
+            }}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};

--- a/src/components/AutoCompleteCanary/types.ts
+++ b/src/components/AutoCompleteCanary/types.ts
@@ -61,6 +61,9 @@ export type AutoCompleteProps<
   onChange?: AutoCompletePropOnChange;
   virtualScroll?: boolean;
   onScrollToBottom?: () => void;
+  onDropdownOpen?: (isOpen: boolean) => void;
+  dropdownOpen?: boolean;
+  ignoreOutsideClicksRefs?: ReadonlyArray<React.RefObject<HTMLElement>>;
 } & Omit<
   TextFieldProps<TYPE>,
   'max' | 'min' | 'step' | 'incrementButtons' | 'onChange' | 'width'

--- a/src/components/AutoCompleteCanary/useAutoComplete.ts
+++ b/src/components/AutoCompleteCanary/useAutoComplete.ts
@@ -148,13 +148,19 @@ export function useAutoComplete<ITEM, GROUP>(
   // Prop Getters
 
   const ArrowUp: KeyHandler = (_, e): void => {
-    e.preventDefault();
-    highlightIndex((old) => old - 1);
+    if (!disabled) {
+      e.preventDefault();
+      setIsOpen.on();
+      highlightIndex((old) => old - 1);
+    }
   };
 
   const ArrowDown: KeyHandler = (_, e): void => {
-    e.preventDefault();
-    highlightIndex((old) => old + 1);
+    if (!disabled) {
+      e.preventDefault();
+      setIsOpen.on();
+      highlightIndex((old) => old + 1);
+    }
   };
 
   const Enter: KeyHandler = (_, e): void => {
@@ -179,15 +185,20 @@ export function useAutoComplete<ITEM, GROUP>(
       if (item) {
         onChange(e, item);
       }
+    } else {
+      setIsOpen.on();
     }
   };
 
-  const Escape = (): void => {
+  const Escape: KeyHandler = (): void => {
     setIsOpen.off();
   };
 
-  const Tab = (): void => {
-    setIsOpen.off();
+  const Tab: KeyHandler = (_, e): void => {
+    if (isOpen) {
+      e.preventDefault();
+      setIsOpen.off();
+    }
   };
 
   const getKeyProps = useKeys({

--- a/src/components/ComboboxCanary/ComboboxCanary.tsx
+++ b/src/components/ComboboxCanary/ComboboxCanary.tsx
@@ -94,6 +94,8 @@ const ComboboxRender = <
     onScrollToBottom,
     onDropdownOpen,
     onSearchValueChange,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
     ...otherProps
   } = usePropsHandler(COMPONENT_NAME, withDefaultGetters(props), controlRef);
 
@@ -137,6 +139,8 @@ const ComboboxRender = <
     searchFunction,
     onDropdownOpen,
     onSearchValueChange,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
   });
 
   const inputId = id ? `${id}-input` : id;

--- a/src/components/ComboboxCanary/ComboboxCanary.tsx
+++ b/src/components/ComboboxCanary/ComboboxCanary.tsx
@@ -23,7 +23,6 @@ import {
 } from '##/components/SelectComponentsCanary/types';
 import { useSelect } from '##/components/SelectComponentsCanary/useSelect';
 import { useForkRef } from '##/hooks/useForkRef';
-import { cnMixFocus } from '##/mixs/MixFocus';
 
 import {
   ComboboxComponent,
@@ -283,7 +282,8 @@ const ComboboxRender = <
               <button
                 type="button"
                 onClick={clearValue}
-                className={cnSelect('ClearIndicator', [cnMixFocus()])}
+                tabIndex={-1}
+                className={cnSelect('ClearIndicator')}
               >
                 <IconClose
                   size="xs"

--- a/src/components/ComboboxCanary/__stand__/Combobox.dev.stand.mdx
+++ b/src/components/ComboboxCanary/__stand__/Combobox.dev.stand.mdx
@@ -22,6 +22,7 @@ import { ComboboxExampleOnSearchValueChange } from './examples/ComboboxExampleOn
 import { ComboboxExampleSelectAll } from './examples/ComboboxExampleSelectAll/ComboboxExampleSelectAll';
 import { ComboboxExampleSearchValue } from './examples/ComboboxExampleSearchValue/ComboboxExampleSearchValue';
 import { ComboboxExampleVirtualScroll } from './examples/ComboboxExampleVirtualScroll/ComboboxExampleVirtualScroll';
+import { ComboboxExampleDropdownOpen } from './examples/ComboboxExampleDropdownOpen/ComboboxExampleDropdownOpen';
 import {
   ComboboxExampleIsLoading,
   ComboboxExampleIsLoadingOnScrollBottom,
@@ -51,6 +52,7 @@ import { Combobox } from '@consta/uikit/ComboboxCanary';
 - [Неактивный выпадающий список](#неактивный-выпадающий-список)
 - [Создание новых вариантов](#создание-новых-вариантов)
 - [Выбор всех элементов](#выбор-всех-элементов)
+- [Управление состоянием выподающего списка](#управление-состоянием-выподающего-списка)
 - [Кастомизация](#кастомизация)
   - [Кастомный элемент списка](#кастомный-элемент-списка)
   - [Кастомное выбранное значение](#кастомное-выбранное-значение)
@@ -107,7 +109,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleItems() {
+function ComboboxExampleItems() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -153,7 +155,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExamplePlaceholder() {
+function ComboboxExamplePlaceholder() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -202,7 +204,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleLabel() {
+function ComboboxExampleLabel() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -251,7 +253,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleDisabledItem() {
+function ComboboxExampleDisabledItem() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -296,7 +298,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleMultiple() {
+function ComboboxExampleMultiple() {
   const [value, setValue] = useState<Item[] | null>();
   return (
     <Combobox
@@ -377,7 +379,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleGroups() {
+function ComboboxExampleGroups() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -424,7 +426,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleStatus() {
+function ComboboxExampleStatus() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -498,7 +500,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleSize() {
+function ComboboxExampleSize() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -543,7 +545,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleForm() {
+function ComboboxExampleForm() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -599,7 +601,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleView() {
+function ComboboxExampleView() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -650,7 +652,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleDisabled() {
+function ComboboxExampleDisabled() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -697,7 +699,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleOnSearchValueChange() {
+function ComboboxExampleOnSearchValueChange() {
   const [value, setValue] = useState<Item | null>();
   const [search, setSearch] = useState<string>('');
   return (
@@ -746,7 +748,7 @@ const groups: Group[] = new Array(items.length / 100)
     label: `Группа ${i + 1}`,
   }));
 
-export const ComboboxExampleVirtualScroll = () => {
+const ComboboxExampleVirtualScroll = () => {
   const [value, setValue] = useState<Item[] | null>();
   return (
     <Combobox
@@ -821,7 +823,7 @@ const useMockLoadData = (
   return [items, isLoading, setIsStart.on];
 };
 
-export const ComboboxExampleIsLoading = () => {
+const ComboboxExampleIsLoading = () => {
   const [value, setValue] = useState<Item[] | null>();
   const [data, isLoading, onDropdownOpen] = useMockLoadData();
 
@@ -913,10 +915,13 @@ const useMockLoadData = (
   return [searchValue && isLoading ? [] : items, isLoading, setIsStart.on];
 };
 
-export const ComboboxExampleIsLoadingOnScrollBottom = () => {
+const ComboboxExampleIsLoadingOnScrollBottom = () => {
   const [value, setValue] = useState<Item[] | null>();
-  const [searchValue, setSearchValue] = useState<string>();
-  const [data, isLoading, onDropdownOpen] = useMockLoadData(searchValue);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [data, isLoading, load] = useMockLoadData(searchValue);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
 
   return (
     <Combobox
@@ -928,7 +933,7 @@ export const ComboboxExampleIsLoadingOnScrollBottom = () => {
       onDropdownOpen={onDropdownOpen}
       isLoading={isLoading}
       virtualScroll
-      onScrollToBottom={searchValue ? undefined : onDropdownOpen}
+      onScrollToBottom={searchValue ? undefined : load}
       searchFunction={() => true}
       onSearchValueChange={setSearchValue}
     />
@@ -966,7 +971,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleCreate() {
+function ComboboxExampleCreate() {
   const [value, setValue] = useState<Item | null>();
   const [list, setList] = useState<Item[]>(items);
   return (
@@ -1052,7 +1057,7 @@ const items: Item[] = [
   },
 ];
 
-export const ComboboxExampleSelectAll = () => {
+const ComboboxExampleSelectAll = () => {
   const [value, setValue] = useState<Item[] | null>();
   return (
     <Combobox
@@ -1069,6 +1074,81 @@ export const ComboboxExampleSelectAll = () => {
 ```
 
 <ComboboxExampleSelectAll />
+
+## Управление состоянием выподающего списка
+
+Для управлением состояния выподающего списка используйте следующие свойства:
+
+- `dropdownOpen` - флаг открыт/закрыт
+- `onDropdownOpen` - колбек отрабатывающий каждый раз при открытии/закрытии
+- `ignoreOutsideClicksRefs` - список ссылок на элементы по которым игнорируется клики
+
+```tsx
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+const ComboboxExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <AnimateIconSwitcherProvider active={open}>
+      <FieldGroup>
+        <Button
+          ref={buttonRef}
+          label={open ? 'Закрыть' : 'Открыть'}
+          onClick={setOpen.toggle}
+          iconLeft={Icon}
+          onlyIcon
+        />
+        <Combobox
+          inputRef={inputRef}
+          placeholder="Выберите вариант"
+          items={items}
+          value={value}
+          onChange={setValue}
+          dropdownOpen={open}
+          onDropdownOpen={onDropdownOpen}
+          ignoreOutsideClicksRefs={[buttonRef]}
+        />
+      </FieldGroup>
+    </AnimateIconSwitcherProvider>
+  );
+};
+```
+
+<ComboboxExampleDropdownOpen />
 
 ## Кастомизация
 
@@ -1135,10 +1215,7 @@ const mapStatus = {
   serviceable: 'success',
 } as const;
 
-export const searchCompare = (
-  searchValue: string,
-  compare?: string,
-): boolean => {
+const searchCompare = (searchValue: string, compare?: string): boolean => {
   if (!compare) {
     return false;
   }
@@ -1158,7 +1235,7 @@ const searchFunction = (item: Item, searchValue: string): boolean => {
   return searchCompare(searchValue, item.status && mapLabel[item.status]);
 };
 
-export function ComboboxExampleRenderItem() {
+function ComboboxExampleRenderItem() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -1224,7 +1301,7 @@ const items: Item[] = [
   },
 ];
 
-export function ComboboxExampleRenderValue() {
+function ComboboxExampleRenderValue() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -1270,7 +1347,7 @@ const defaultGetGroupLabel = (group) => group.label;
 import React, { useState } from 'react';
 import { Combobox } from '@consta/uikit/ComboboxCanary';
 
-export function ComboboxExampleCustomTypes() {
+function ComboboxExampleCustomTypes() {
   const [value, setValue] = useState<string | null>();
   return (
     <Combobox
@@ -1293,12 +1370,12 @@ export function ComboboxExampleCustomTypes() {
 import React, { useState } from 'react';
 import { Combobox } from '@consta/uikit/ComboboxCanary';
 
-export type Item = {
+type Item = {
   name: string;
   group: string;
 };
 
-export const items: Item[] = [
+const items: Item[] = [
   { name: 'Первый', group: 'Первая группа' },
   { name: 'Второй', group: 'Третья группа' },
   { name: 'Третий', group: 'Вторая группа' },
@@ -1311,13 +1388,9 @@ export const items: Item[] = [
   { name: 'Десятый', group: 'Вторая группа' },
 ];
 
-export const groups: string[] = [
-  'Первая группа',
-  'Вторая группа',
-  'Третья группа',
-];
+const groups: string[] = ['Первая группа', 'Вторая группа', 'Третья группа'];
 
-export function ComboboxExampleCustomTypesWithGroups() {
+function ComboboxExampleCustomTypesWithGroups() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Combobox
@@ -1343,7 +1416,7 @@ export function ComboboxExampleCustomTypesWithGroups() {
 Для того, чтобы программным путем изменить значение поля ввода, используйте `searchValue`.
 
 ```tsx
-export function ComboboxExampleSearchValue() {
+function ComboboxExampleSearchValue() {
   const [value, setValue] = useState<Item[] | null>();
   const [searchValue, setSearchValue] = useState<string | undefined>();
 
@@ -1431,49 +1504,51 @@ type PropGetGroupKey<GROUP> = (group: GROUP) => string | number;
 type PropGetGroupLabel<GROUP> = (group: GROUP) => string;
 ```
 
-| Свойство                                                  | Тип или варианты значения                                      | По умолчанию                                                  | Описание                                                               |
-| --------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [`view?`](#внешний-вид)                                   | `default` , `clear`                                            | `default`                                                     | Внешний вид компонента                                                 |
-| [`disabled?`](#отключение-поля-ввода)                     | `boolean`                                                      | -                                                             | Делает компонент недоступным                                           |
-| [`status?`](#статус-поля)                                 | `'', 'alert', 'success', 'warning'`                            | `' '`                                                         | Тип поля                                                               |
-| [`size?`](#размер)                                        | `'xs'`, `'s'` , `'m'` , `'l'`                                  | `'m'`                                                         | Размер компонента                                                      |
-| [`form?`](#форма)                                         | `default`, `brick`, `round`                                    | `default`                                                     | Форма компонента                                                       |
-| [`placeholder?`](#подсказка)                              | `string`                                                       | -                                                             | Подсказка, отображается, когда вариант не выбран                       |
-| [`label?`](#лейбл-и-подпись)                              | `string`                                                       | -                                                             | Лейбл                                                                  |
-| [`labelIcon?`](#лейбл-и-подпись)                          | `IconComponent`                                                | -                                                             | Иконка слева от лейбла                                                 |
-| [`labelPosition?`](#лейбл-и-подпись)                      | `'top', 'left'`                                                | `'top'`                                                       | Положение лейбла                                                       |
-| [`caption?`](#лейбл-и-подпись)                            | `string`                                                       | -                                                             | Подпись                                                                |
-| [`items`](#варианты)                                      | `ITEM[]`                                                       | -                                                             | Варианты                                                               |
-| [`value?`](#значение)                                     | `PropValue<ITEM,MULTIPLE>`                                     | -                                                             | Значение селекта                                                       |
-| [`onChange?`](#onchange)                                  | `PropOnChange<ITEM,MULTIPLE>`                                  | -                                                             | Событие связанное с изменением значения компонента                     |
-| [`multiple?`](#множественный-выбор)                       | `boolean`                                                      | `false`                                                       | Указатель множественного выбора                                        |
-| [`groups?`](#группировка-списка)                          | `GROUP[]`                                                      | -                                                             | Группы                                                                 |
-| [`onSearchValueChange?`](#поиск)                          | `(value: string) => void;`                                     | -                                                             | Функция для получения значения строки поиска                           |
-| [`searchFunction?`](#поиск)                               | `PropSearchFunction<ITEM>`                                     | поиск по `label` элементов, `label` получен из `getItemLabel` | Функция поиска                                                         |
-| [`renderItem?`](#свое-представление-элемента-списка)      | `PropRenderItem<ITEM>`                                         | рендер по умолчанию                                           | Рендер-функция для элемента списка                                     |
-| [`renderValue?`](#свое-представление-выбранного-значения) | `PropRenderValue<ITEM>`                                        | рендер по умолчанию                                           | Рендер-функция для элемента значения                                   |
-| [`getItemLabel?`](#свои-тип-данных-items-и-groups)        | `PropGetItemLabel<ITEM>`                                       | `(item) => item.label`                                        | Функция для определения названия элемента                              |
-| [`getItemKey?`](#свои-тип-данных-items-и-groups)          | `PropGetItemKey<ITEM>`                                         | `(item) => item.id`                                           | Функция для определения уникального ключа элемента                     |
-| [`getItemGroupKey?`](#свои-тип-данных-items-и-groups)     | `PropGetItemGroupKey<ITEM>`                                    | `(item) => item.groupId`                                      | Функция для определения ключа группы, к которой будет привязан элемент |
-| [`getItemDisabled?`](#свои-тип-данных-items-и-groups)     | `PropGetItemDisabled<ITEM>`                                    | `(item) => item.disabled`                                     | Функция для определения состояния `disabled`                           |
-| [`getGroupLabel?`](#свои-тип-данных-items-и-groups)       | `PropGetGroupKey<GROUP>`                                       | `(group) => group.id`                                         | Функция для определения названия группы                                |
-| [`getGroupKey?`](#свои-тип-данных-items-и-groups)         | `PropGetGroupLabel<GROUP>`                                     | `(group) => group.label`                                      | Функция для определения уникального ключа группы                       |
-| `isLoading?`                                              | `boolean`                                                      | -                                                             | При `true` будет отображаться лоудер загрузки                          |
-| `required?`                                               | `boolean`                                                      | -                                                             | Нужно заполнить                                                        |
-| `searchValue?`                                            | `string`                                                       | -                                                             | Значение поля ввода                                                    |
-| `labelForEmptyItems?`                                     | `string`                                                       | `Список пуст`                                                 | Текст, который нужно показать, если в списке нет значений              |
-| [`labelForNotFound?`](#поиск)                             | `string`                                                       | `Не найдено`                                                  | Текст, который нужно показать, если при поиске ничего не нашлось       |
-| [`labelForCreate?`](#создание-новых-вариантов)            | `string`                                                       | `+`                                                           | Текст для кнопки, по которой можно добавить элемент в список           |
-| [`selectAll?`](#выбор-всех-элементов)                     | `boolean`                                                      | `false`                                                       | Добавляет пункт списка с возможностью выбора всех элементов            |
-| `onBlur?`                                                 | `(event?: React.FocusEvent<HTMLInputElement>) => void`         | -                                                             | Обработчик события `blur`                                              |
-| `onFocus?`                                                | `(event?: React.FocusEvent<HTMLInputElement>) => void`         | -                                                             | Обработчик события `focus`                                             |
-| `onCreate?`                                               | `() => void;`                                                  | -                                                             | Событие по клику на кнопку 'Создать'                                   |
-| `onScrollToBottom?`                                       | `(label: string, props: { e: React.SyntheticEvent }) => void;` | -                                                             | Событие срабатывает когда доскролили список до конца                   |
-| `onSearchValueChange?`                                    | `(value: string) => void;`                                     | -                                                             | Событие срабатывает при изменении значения поиска                      |
-| `onDropdownOpen?`                                         | `() => void;`                                                  | -                                                             | Событие срабатывает при открытии списка                                |
-| `virtualScroll?`                                          | `boolean`                                                      | -                                                             | Включает виртуализацию скролла                                         |
-| `ariaLabel?`                                              | `string`                                                       | -                                                             | `aria` атрибут для поля ввода                                          |
-| `name?`                                                   | `string`                                                       | -                                                             | Имя поля ввода                                                         |
-| `className?`                                              | `string`                                                       | -                                                             | Дополнительный CSS-класс                                               |
-| `dropdownClassName?`                                      | `string`                                                       | -                                                             | Дополнительный CSS-класс для выпадающего блока                         |
-| `ref?`                                                    | `React.Ref<HTMLDivElement>`                                    | -                                                             | Ссылка на корневой DOM-элемент компонента                              |
+| Свойство                                                                | Тип или варианты значения                                     | По умолчанию                                                  | Описание                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [`view?`](#внешний-вид)                                                 | `default` , `clear`                                           | `default`                                                     | Внешний вид компонента                                                    |
+| [`disabled?`](#отключение-поля-ввода)                                   | `boolean`                                                     | -                                                             | Делает компонент недоступным                                              |
+| [`status?`](#статус-поля)                                               | `'', 'alert', 'success', 'warning'`                           | `' '`                                                         | Тип поля                                                                  |
+| [`size?`](#размер)                                                      | `'xs'`, `'s'` , `'m'` , `'l'`                                 | `'m'`                                                         | Размер компонента                                                         |
+| [`form?`](#форма)                                                       | `default`, `brick`, `round`                                   | `default`                                                     | Форма компонента                                                          |
+| [`placeholder?`](#подсказка)                                            | `string`                                                      | -                                                             | Подсказка, отображается, когда вариант не выбран                          |
+| [`label?`](#лейбл-и-подпись)                                            | `string`                                                      | -                                                             | Лейбл                                                                     |
+| [`labelIcon?`](#лейбл-и-подпись)                                        | `IconComponent`                                               | -                                                             | Иконка слева от лейбла                                                    |
+| [`labelPosition?`](#лейбл-и-подпись)                                    | `'top', 'left'`                                               | `'top'`                                                       | Положение лейбла                                                          |
+| [`caption?`](#лейбл-и-подпись)                                          | `string`                                                      | -                                                             | Подпись                                                                   |
+| [`items`](#варианты)                                                    | `ITEM[]`                                                      | -                                                             | Варианты                                                                  |
+| [`value?`](#значение)                                                   | `PropValue<ITEM,MULTIPLE>`                                    | -                                                             | Значение селекта                                                          |
+| [`onChange?`](#onchange)                                                | `PropOnChange<ITEM,MULTIPLE>`                                 | -                                                             | Событие связанное с изменением значения компонента                        |
+| [`multiple?`](#множественный-выбор)                                     | `boolean`                                                     | `false`                                                       | Указатель множественного выбора                                           |
+| [`groups?`](#группировка-списка)                                        | `GROUP[]`                                                     | -                                                             | Группы                                                                    |
+| [`onSearchValueChange?`](#поиск)                                        | `(value: string) => void`                                     | -                                                             | Функция для получения значения строки поиска                              |
+| [`searchFunction?`](#поиск)                                             | `PropSearchFunction<ITEM>`                                    | поиск по `label` элементов, `label` получен из `getItemLabel` | Функция поиска                                                            |
+| [`renderItem?`](#свое-представление-элемента-списка)                    | `PropRenderItem<ITEM>`                                        | рендер по умолчанию                                           | Рендер-функция для элемента списка                                        |
+| [`renderValue?`](#свое-представление-выбранного-значения)               | `PropRenderValue<ITEM>`                                       | рендер по умолчанию                                           | Рендер-функция для элемента значения                                      |
+| [`getItemLabel?`](#свои-тип-данных-items-и-groups)                      | `PropGetItemLabel<ITEM>`                                      | `(item) => item.label`                                        | Функция для определения названия элемента                                 |
+| [`getItemKey?`](#свои-тип-данных-items-и-groups)                        | `PropGetItemKey<ITEM>`                                        | `(item) => item.id`                                           | Функция для определения уникального ключа элемента                        |
+| [`getItemGroupKey?`](#свои-тип-данных-items-и-groups)                   | `PropGetItemGroupKey<ITEM>`                                   | `(item) => item.groupId`                                      | Функция для определения ключа группы, к которой будет привязан элемент    |
+| [`getItemDisabled?`](#свои-тип-данных-items-и-groups)                   | `PropGetItemDisabled<ITEM>`                                   | `(item) => item.disabled`                                     | Функция для определения состояния `disabled`                              |
+| [`getGroupLabel?`](#свои-тип-данных-items-и-groups)                     | `PropGetGroupKey<GROUP>`                                      | `(group) => group.id`                                         | Функция для определения названия группы                                   |
+| [`getGroupKey?`](#свои-тип-данных-items-и-groups)                       | `PropGetGroupLabel<GROUP>`                                    | `(group) => group.label`                                      | Функция для определения уникального ключа группы                          |
+| [`isLoading?`](#индикация-загрузки)                                     | `boolean`                                                     | -                                                             | При `true` будет отображаться лоадер загрузки                             |
+| `required?`                                                             | `boolean`                                                     | -                                                             | Нужно заполнить                                                           |
+| `searchValue?`                                                          | `string`                                                      | -                                                             | Значение поля ввода                                                       |
+| `labelForEmptyItems?`                                                   | `string`                                                      | `Список пуст`                                                 | Текст, который нужно показать, если в списке нет значений                 |
+| [`labelForNotFound?`](#поиск)                                           | `string`                                                      | `Не найдено`                                                  | Текст, который нужно показать, если при поиске ничего не нашлось          |
+| [`labelForCreate?`](#создание-новых-вариантов)                          | `string`                                                      | `+`                                                           | Текст для кнопки, по которой можно добавить элемент в список              |
+| [`selectAll?`](#выбор-всех-элементов)                                   | `boolean`                                                     | `false`                                                       | Добавляет пункт списка с возможностью выбора всех элементов               |
+| `onBlur?`                                                               | `(event?: React.FocusEvent<HTMLInputElement>) => void`        | -                                                             | Обработчик события `blur`                                                 |
+| `onFocus?`                                                              | `(event?: React.FocusEvent<HTMLInputElement>) => void`        | -                                                             | Обработчик события `focus`                                                |
+| `onCreate?`                                                             | `() => void;`                                                 | -                                                             | Событие по клику на кнопку 'Создать'                                      |
+| `onScrollToBottom?`                                                     | `(label: string, props: { e: React.SyntheticEvent }) => void` | -                                                             | Событие срабатывает когда доскролили список до конца                      |
+| `onSearchValueChange?`                                                  | `(value: string) => void;`                                    | -                                                             | Событие срабатывает при изменении значения поиска                         |
+| `virtualScroll?`                                                        | `boolean`                                                     | -                                                             | Включает виртуализацию скролла                                            |
+| `ariaLabel?`                                                            | `string`                                                      | -                                                             | `aria` атрибут для поля ввода                                             |
+| `name?`                                                                 | `string`                                                      | -                                                             | Имя поля ввода                                                            |
+| `className?`                                                            | `string`                                                      | -                                                             | Дополнительный CSS-класс                                                  |
+| `dropdownClassName?`                                                    | `string`                                                      | -                                                             | Дополнительный CSS-класс для выпадающего блока                            |
+| [`onDropdownOpen?`](#управление-состоянием-выподающего-списка)          | `(open: boolean) => void;`                                    | -                                                             | Событие срабатывает при открытии списка                                   |
+| [`dropdownOpen?` ](#управление-состоянием-выподающего-списка)           | `boolean`                                                     | -                                                             | Состояние открыт/закрыт выподающего списка                                |
+| [`ignoreOutsideClicksRefs?`](#управление-состоянием-выподающего-списка) | `ReadonlyArray<React.RefObject<HTMLElement>>`                 | -                                                             | Ссылки на элементы с которые нужно игнорировать при кликах вне компонента |
+| `ref?`                                                                  | `React.Ref<HTMLDivElement>`                                   | -                                                             | Ссылка на корневой DOM-элемент компонента                                 |

--- a/src/components/ComboboxCanary/__stand__/examples/ComboboxExampleDropdownOpen/ComboboxExampleDropdownOpen.tsx
+++ b/src/components/ComboboxCanary/__stand__/examples/ComboboxExampleDropdownOpen/ComboboxExampleDropdownOpen.tsx
@@ -1,0 +1,76 @@
+import { AnimateIconSwitcherProvider } from '@consta/icons/AnimateIconSwitcherProvider';
+import { IconArrowDown } from '@consta/icons/IconArrowDown';
+import { withAnimateSwitcherHOC } from '@consta/icons/withAnimateSwitcherHOC';
+import { Example } from '@consta/stand';
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Button } from '##/components/Button';
+import { FieldGroup } from '##/components/FieldGroup';
+import { useFlag } from '##/hooks/useFlag';
+
+import { Combobox } from '../../../ComboboxCanary';
+
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const ComboboxExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <Combobox
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreOutsideClicksRefs={[buttonRef]}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};

--- a/src/components/ComboboxCanary/__stand__/examples/ComboboxExampleIsLoading/ComboboxExampleIsLoading.tsx
+++ b/src/components/ComboboxCanary/__stand__/examples/ComboboxExampleIsLoading/ComboboxExampleIsLoading.tsx
@@ -1,5 +1,5 @@
 import { Example } from '@consta/stand';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDebounce } from '##/hooks/useDebounce';
 import { useFlag } from '##/hooks/useFlag';
@@ -97,7 +97,10 @@ export const ComboboxExampleIsLoading = () => {
 export const ComboboxExampleIsLoadingOnScrollBottom = () => {
   const [value, setValue] = useState<Item[] | null>();
   const [searchValue, setSearchValue] = useState<string>('');
-  const [data, isLoading, onDropdownOpen] = useMockLoadData(searchValue);
+  const [data, isLoading, load] = useMockLoadData(searchValue);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
 
   return (
     <Example col={1}>
@@ -110,7 +113,7 @@ export const ComboboxExampleIsLoadingOnScrollBottom = () => {
         onDropdownOpen={onDropdownOpen}
         isLoading={isLoading}
         virtualScroll
-        onScrollToBottom={searchValue ? undefined : onDropdownOpen}
+        onScrollToBottom={searchValue ? undefined : load}
         searchFunction={() => true}
         onSearchValueChange={setSearchValue}
       />

--- a/src/components/ComboboxCanary/helpers.ts
+++ b/src/components/ComboboxCanary/helpers.ts
@@ -102,7 +102,9 @@ export type ComboboxProps<
     virtualScroll?: boolean;
     onScrollToBottom?: () => void;
     onSearchValueChange?: (value: string) => void;
-    onDropdownOpen?: () => void;
+    onDropdownOpen?: (isOpen: boolean) => void;
+    dropdownOpen?: boolean;
+    ignoreOutsideClicksRefs?: ReadonlyArray<React.RefObject<HTMLElement>>;
   },
   HTMLDivElement
 > &

--- a/src/components/SelectCanary/SelectCanary.tsx
+++ b/src/components/SelectCanary/SelectCanary.tsx
@@ -71,6 +71,8 @@ const SelectRender = <ITEM = DefaultItem, GROUP = DefaultGroup>(
     onDropdownOpen,
     onScrollToBottom,
     virtualScroll,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
     ...restProps
   } = usePropsHandler(COMPONENT_NAME, withDefaultGetters(props), controlRef);
 
@@ -105,6 +107,8 @@ const SelectRender = <ITEM = DefaultItem, GROUP = DefaultGroup>(
     onBlur,
     onFocus,
     onDropdownOpen,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
   });
 
   const inputId = id ? `${id}-input` : id;

--- a/src/components/SelectCanary/SelectCanary.tsx
+++ b/src/components/SelectCanary/SelectCanary.tsx
@@ -169,7 +169,8 @@ const SelectRender = <ITEM = DefaultItem, GROUP = DefaultGroup>(
             <div className={cnSelect('ControlValueContainer')}>
               <input
                 {...getKeyProps()}
-                type="button"
+                className={cnSelect('FakeField')}
+                type="text"
                 name={name}
                 id={inputId}
                 onFocus={handleInputFocus}
@@ -177,7 +178,6 @@ const SelectRender = <ITEM = DefaultItem, GROUP = DefaultGroup>(
                 aria-label={ariaLabel}
                 onClick={handleInputClick}
                 ref={useForkRef([inputRef, inputRefProp])}
-                className={cnSelect('FakeField')}
                 readOnly
               />
               {value && renderValue({ item: value })}

--- a/src/components/SelectCanary/__stand__/Select.dev.stand.mdx
+++ b/src/components/SelectCanary/__stand__/Select.dev.stand.mdx
@@ -11,6 +11,7 @@ import { SelectExampleDisabledItem } from './examples/SelectExampleDisabledItem/
 import { SelectExampleGroups } from './examples/SelectExampleGroups/SelectExampleGroups';
 import { SelectExampleVirtualScroll } from './examples/SelectExampleVirtualScroll/SelectExampleVirtualScroll';
 import { SelectExampleIsLoading } from './examples/SelectExampleIsLoading/SelectExampleIsLoading';
+import { SelectExampleDropdownOpen } from './examples/SelectExampleDropdownOpen/SelectExampleDropdownOpen';
 import {
   SelectExampleCustomTypes,
   SelectExampleCustomTypesWithGroups,
@@ -41,6 +42,7 @@ import { Select } from '@consta/uikit/Select';
 - [Индикация загрузки](#индикация-загрузки)
 - [Лейбл и подпись](#лейбл-и-подпись)
 - [Неактивный выпадающий список](#неактивный-выпадающий-список)
+- [Управление состоянием выподающего списка](#управление-состоянием-выподающего-списка)
 - [Кастомизация](#кастомизация)
   - [Кастомный элемент списка](#кастомный-элемент-списка)
   - [Кастомное выбранное значение](#кастомное-выбранное-значение)
@@ -110,7 +112,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleItems() {
+function SelectExampleItems() {
   const [value, setValue] = useState<Item | null>();
   return <Select items={items} value={value} onChange={setValue} />;
 }
@@ -146,7 +148,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExamplePlaceholder() {
+function SelectExamplePlaceholder() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -190,7 +192,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleDisabledItem() {
+function SelectExampleDisabledItem() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -267,7 +269,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleGroups() {
+function SelectExampleGroups() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -311,7 +313,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleStatus() {
+function SelectExampleStatus() {
   const [value, setValue] = useState<Item | null>();
   return (
     <>
@@ -384,7 +386,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleSize() {
+function SelectExampleSize() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -427,7 +429,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleForm() {
+function SelectExampleForm() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -480,7 +482,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleView() {
+function SelectExampleView() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -525,7 +527,7 @@ const groups: Group[] = new Array(items.length / 100)
     label: `Группа ${i + 1}`,
   }));
 
-export const SelectExampleVirtualScroll = () => {
+const SelectExampleVirtualScroll = () => {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -547,6 +549,97 @@ export const SelectExampleVirtualScroll = () => {
 Для отображения индикации загрузки укажите параметр `isLoading`
 
 Пример ниже показывает, как можно загрузить данные после раскрытия списка.
+
+```tsx
+type Item = {
+  label: string;
+  id: number;
+};
+
+const useMockLoadData = (
+  searchValue = '',
+  timeout = 2000,
+): [Item[], boolean, () => void] => {
+  const [isLoading, setIsLoading] = useFlag();
+  const [isStart, setIsStart] = useFlag();
+  const [lenght, setLenght] = useState<number>(0);
+  const isLoadingOffDebounce = useDebounce(setIsLoading.off, 2000);
+
+  const items = useMemo(() => {
+    if (searchValue) {
+      return new Array(10000)
+        .fill(null)
+        .map((_, i) => ({
+          label: `Опция ${i + 1}`,
+          id: i,
+        }))
+        .filter(
+          (item) =>
+            item.label
+              .toLocaleLowerCase()
+              .indexOf(searchValue.toLocaleLowerCase()) !== -1,
+        );
+    }
+    return new Array(lenght).fill(null).map((_, i) => ({
+      label: `Опция ${i + 1}`,
+      id: i,
+    }));
+  }, [lenght, searchValue]);
+
+  useEffect(() => {
+    setIsLoading.on();
+    isLoadingOffDebounce();
+  }, [searchValue]);
+
+  useEffect(() => {
+    if (isStart) {
+      setIsLoading.on();
+    }
+
+    const timeoutNumber = setTimeout(() => {
+      if (isStart) {
+        setLenght((state) => state + 100);
+        setIsLoading.off();
+        setIsStart.off();
+      }
+    }, timeout);
+
+    return () => {
+      clearTimeout(timeoutNumber);
+    };
+  }, [isStart]);
+
+  useEffect(() => {
+    return () => {
+      setIsLoading.off();
+      setIsStart.off();
+    };
+  }, []);
+
+  return [searchValue && isLoading ? [] : items, isLoading, setIsStart.on];
+};
+
+const SelectExampleIsLoading = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [data, isLoading, load] = useMockLoadData();
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
+
+  return (
+    <Select
+      placeholder="Кликните по полю ввода, чтобы данные загрузились"
+      items={data}
+      value={value}
+      onChange={setValue}
+      onDropdownOpen={onDropdownOpen}
+      isLoading={isLoading}
+      virtualScroll
+      onScrollToBottom={load}
+    />
+  );
+};
+```
 
 <SelectExampleIsLoading />
 
@@ -576,7 +669,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleLabel() {
+function SelectExampleLabel() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -626,7 +719,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleDisabled() {
+function SelectExampleDisabled() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -641,6 +734,81 @@ export function SelectExampleDisabled() {
 ```
 
 <SelectExampleDisabled />
+
+## Управление состоянием выподающего списка
+
+Для управлением состояния выподающего списка используйте следующие свойства:
+
+- `dropdownOpen` - флаг открыт/закрыт
+- `onDropdownOpen` - колбек отрабатывающий каждый раз при открытии/закрытии
+- `ignoreClicksInsideRefs` - список ссылок на элементы по которым игнорируется клики
+
+```tsx
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+const SelectExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <AnimateIconSwitcherProvider active={open}>
+      <FieldGroup>
+        <Button
+          ref={buttonRef}
+          label={open ? 'Закрыть' : 'Открыть'}
+          onClick={setOpen.toggle}
+          iconLeft={Icon}
+          onlyIcon
+        />
+        <Select
+          inputRef={inputRef}
+          placeholder="Выберите вариант"
+          items={items}
+          value={value}
+          onChange={setValue}
+          dropdownOpen={open}
+          onDropdownOpen={onDropdownOpen}
+          ignoreClicksInsideRefs={[buttonRef]}
+        />
+      </FieldGroup>
+    </AnimateIconSwitcherProvider>
+  );
+};
+```
+
+<SelectExampleDropdownOpen />
 
 ## Кастомизация
 
@@ -674,7 +842,7 @@ const items: Item[] = [
 
 const cnSelectExampleRenderItem = cn('SelectExampleRenderItem');
 
-export function SelectExampleRenderItem() {
+function SelectExampleRenderItem() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -726,7 +894,7 @@ const items: Item[] = [
   },
 ];
 
-export function SelectExampleRenderValue() {
+function SelectExampleRenderValue() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -772,7 +940,7 @@ const defaultGetGroupLabel = (group) => group.label;
 #### Пример с кастомным Item
 
 ```tsx
-export function SelectExampleCustomTypes() {
+function SelectExampleCustomTypes() {
   const [value, setValue] = useState<string | null>();
   return (
     <Select
@@ -792,12 +960,12 @@ export function SelectExampleCustomTypes() {
 #### Пример с кастомными Item и Group
 
 ```tsx
-export type Item = {
+type Item = {
   name: string;
   group: string;
 };
 
-export const items: Item[] = [
+const items: Item[] = [
   { name: 'Первый', group: 'Первая группа' },
   { name: 'Второй', group: 'Третья группа' },
   { name: 'Третий', group: 'Вторая группа' },
@@ -810,13 +978,9 @@ export const items: Item[] = [
   { name: 'Десятый', group: 'Вторая группа' },
 ];
 
-export const groups: string[] = [
-  'Первая группа',
-  'Вторая группа',
-  'Третья группа',
-];
+const groups: string[] = ['Первая группа', 'Вторая группа', 'Третья группа'];
 
-export function SelectExampleCustomTypesWithGroups() {
+function SelectExampleCustomTypesWithGroups() {
   const [value, setValue] = useState<Item | null>();
   return (
     <Select
@@ -886,39 +1050,41 @@ type PropGetGroupKey<GROUP> = (group: GROUP) => string | number;
 type PropGetGroupLabel<GROUP> = (group: GROUP) => string;
 ```
 
-| Свойство                                                           | Тип или варианты значения                              | По умолчанию              | Описание                                                               |
-| ------------------------------------------------------------------ | ------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------- |
-| [`view?`](#внешний-вид)                                            | `default` , `clear`                                    | `default`                 | Внешний вид компонента                                                 |
-| [`disabled?`](#неактивный-выпадающий-список)                       | `boolean`                                              | -                         | Делает компонент неактивным                                            |
-| [`status?`](#статус-поля)                                          | `'', 'alert', 'success', 'warning'`                    | `' '`                     | Тип поля                                                               |
-| [`size?`](#размер)                                                 | `'xs'`, `'s'` , `'m'` , `'l'`                          | `'m'`                     | Размер компонента                                                      |
-| [`form?`](#форма)                                                  | `default`, `brick`, `round`                            | `default`                 | Форма компонента                                                       |
-| [`placeholder?`](#подсказка)                                       | `string`                                               | -                         | Подсказка. Отображается, когда вариант не выбран                       |
-| [`label?`](#лейбл-и-подпись)                                       | `string`                                               | -                         | Лейбл                                                                  |
-| [`labelPosition?`](#лейбл-и-подпись)                               | `'top', 'left'`                                        | `'top'`                   | Положение лейбла                                                       |
-| [`caption?`](#лейбл-и-подпись)                                     | `string`                                               | -                         | Подпись                                                                |
-| [`items`](#варианты)                                               | `ITEM[]`                                               | -                         | Варианты                                                               |
-| [`value?`](#выбранное-значение)                                    | `ITEM`, `null`                                         | -                         | Выбранное значение                                                     |
-| [`onChange?`](#выбранное-значение)                                 | `PropOnChange<ITEM>`                                   | -                         | Обработчик события изменения значения компонента                       |
-| [`groups?`](#группы-вариантов)                                     | `GROUP[]`                                              | -                         | Группы вариантов                                                       |
-| [`renderItem?`](#кастомный-элемент-списка)                         | `PropRenderItem<ITEM>`                                 | рендер по умолчанию       | Рендер-функция для элемента списка                                     |
-| [`renderValue?`](#кастомное-выбранное-значение)                    | `PropRenderValue<ITEM>`                                | рендер по умолчанию       | Рендер-функция для выбранного значения                                 |
-| [`getItemLabel?`](#)                                               | `PropGetItemLabel<ITEM>`                               | `(item) => item.label`    | Функция для определения названия элемента                              |
-| [`getItemKey?`](#кастомные-типы-данных-для-вариантов-и-групп)      | `PropGetItemKey<ITEM>`                                 | `(item) => item.id`       | Функция для определения уникального ключа элемента                     |
-| [`getItemGroupKey?`](#кастомные-типы-данных-для-вариантов-и-групп) | `PropGetItemGroupKey<ITEM>`                            | `(item) => item.groupId`  | Функция для определения ключа группы, к которой будет привязан элемент |
-| [`getItemDisabled?`](#кастомные-типы-данных-для-вариантов-и-групп) | `PropGetItemDisabled<ITEM>`                            | `(item) => item.disabled` | Функция для определения неактивного варианта (`disabled`)              |
-| [`getGroupLabel?`](#кастомные-типы-данных-для-вариантов-и-групп)   | `PropGetGroupKey<GROUP>`                               | `(group) => group.id`     | Функция для определения названия группы                                |
-| [`getGroupKey?`](#кастомные-типы-данных-для-вариантов-и-групп)     | `PropGetGroupLabel<GROUP>`                             | `(group) => group.label`  | Функция для определения уникального ключа группы                       |
-| `isLoading?`                                                       | `boolean`                                              | -                         | При `true` будет отображаться лоадер загрузки                          |
-| `virtualScroll?`                                                   | `boolean`                                              | -                         | Включает виртуализацию скролла                                         |
-| `onScrollToBottom?`                                                | `() => void`                                           | -                         | Колбэк сработает при сроое до конца списка                             |
-| `onDropdownOpen?`                                                  | `() => void`                                           | -                         | Колбэк сработает при при открытии дропдауна                            |
-| `required?`                                                        | `boolean`                                              | -                         | Нужно заполнить                                                        |
-| `labelForEmptyItems?`                                              | `string`                                               | `Список пуст`             | Текст для случая, когда в списке нет значений                          |
-| `onBlur?`                                                          | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                         | Обработчик события `blur`                                              |
-| `onFocus?`                                                         | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                         | Обработчик события `focus`                                             |
-| `ariaLabel?`                                                       | `string`                                               | -                         | `aria` атрибут для поля ввода                                          |
-| `name?`                                                            | `string`                                               | -                         | Имя поля ввода                                                         |
-| `className?`                                                       | `string`                                               | -                         | Дополнительный CSS-класс                                               |
-| `dropdownClassName?`                                               | `string`                                               | -                         | Дополнительный CSS-класс для выпадающего блока                         |
-| `ref?`                                                             | `React.Ref<HTMLDivElement>`                            | -                         | Ссылка на корневой DOM-элемент компонента                              |
+| Свойство                                                                | Тип или варианты значения                              | По умолчанию              | Описание                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- | ------------------------------------------------------------------------- |
+| [`view?`](#внешний-вид)                                                 | `default` , `clear`                                    | `default`                 | Внешний вид компонента                                                    |
+| [`disabled?`](#неактивный-выпадающий-список)                            | `boolean`                                              | -                         | Делает компонент неактивным                                               |
+| [`status?`](#статус-поля)                                               | `'', 'alert', 'success', 'warning'`                    | `' '`                     | Тип поля                                                                  |
+| [`size?`](#размер)                                                      | `'xs'`, `'s'` , `'m'` , `'l'`                          | `'m'`                     | Размер компонента                                                         |
+| [`form?`](#форма)                                                       | `default`, `brick`, `round`                            | `default`                 | Форма компонента                                                          |
+| [`placeholder?`](#подсказка)                                            | `string`                                               | -                         | Подсказка. Отображается, когда вариант не выбран                          |
+| [`label?`](#лейбл-и-подпись)                                            | `string`                                               | -                         | Лейбл                                                                     |
+| [`labelPosition?`](#лейбл-и-подпись)                                    | `'top', 'left'`                                        | `'top'`                   | Положение лейбла                                                          |
+| [`caption?`](#лейбл-и-подпись)                                          | `string`                                               | -                         | Подпись                                                                   |
+| [`items`](#варианты)                                                    | `ITEM[]`                                               | -                         | Варианты                                                                  |
+| [`value?`](#выбранное-значение)                                         | `ITEM`, `null`                                         | -                         | Выбранное значение                                                        |
+| [`onChange?`](#выбранное-значение)                                      | `PropOnChange<ITEM>`                                   | -                         | Обработчик события изменения значения компонента                          |
+| [`groups?`](#группы-вариантов)                                          | `GROUP[]`                                              | -                         | Группы вариантов                                                          |
+| [`renderItem?`](#кастомный-элемент-списка)                              | `PropRenderItem<ITEM>`                                 | рендер по умолчанию       | Рендер-функция для элемента списка                                        |
+| [`renderValue?`](#кастомное-выбранное-значение)                         | `PropRenderValue<ITEM>`                                | рендер по умолчанию       | Рендер-функция для выбранного значения                                    |
+| [`getItemLabel?`](#)                                                    | `PropGetItemLabel<ITEM>`                               | `(item) => item.label`    | Функция для определения названия элемента                                 |
+| [`getItemKey?`](#кастомные-типы-данных-для-вариантов-и-групп)           | `PropGetItemKey<ITEM>`                                 | `(item) => item.id`       | Функция для определения уникального ключа элемента                        |
+| [`getItemGroupKey?`](#кастомные-типы-данных-для-вариантов-и-групп)      | `PropGetItemGroupKey<ITEM>`                            | `(item) => item.groupId`  | Функция для определения ключа группы, к которой будет привязан элемент    |
+| [`getItemDisabled?`](#кастомные-типы-данных-для-вариантов-и-групп)      | `PropGetItemDisabled<ITEM>`                            | `(item) => item.disabled` | Функция для определения неактивного варианта (`disabled`)                 |
+| [`getGroupLabel?`](#кастомные-типы-данных-для-вариантов-и-групп)        | `PropGetGroupKey<GROUP>`                               | `(group) => group.id`     | Функция для определения названия группы                                   |
+| [`getGroupKey?`](#кастомные-типы-данных-для-вариантов-и-групп)          | `PropGetGroupLabel<GROUP>`                             | `(group) => group.label`  | Функция для определения уникального ключа группы                          |
+| `isLoading?`                                                            | `boolean`                                              | -                         | При `true` будет отображаться лоадер загрузки                             |
+| `virtualScroll?`                                                        | `boolean`                                              | -                         | Включает виртуализацию скролла                                            |
+| `onScrollToBottom?`                                                     | `() => void`                                           | -                         | Колбэк сработает при сроое до конца списка                                |
+| `required?`                                                             | `boolean`                                              | -                         | Нужно заполнить                                                           |
+| `labelForEmptyItems?`                                                   | `string`                                               | `Список пуст`             | Текст для случая, когда в списке нет значений                             |
+| `onBlur?`                                                               | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                         | Обработчик события `blur`                                                 |
+| `onFocus?`                                                              | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                         | Обработчик события `focus`                                                |
+| `ariaLabel?`                                                            | `string`                                               | -                         | `aria` атрибут для поля ввода                                             |
+| `name?`                                                                 | `string`                                               | -                         | Имя поля ввода                                                            |
+| `className?`                                                            | `string`                                               | -                         | Дополнительный CSS-класс                                                  |
+| `dropdownClassName?`                                                    | `string`                                               | -                         | Дополнительный CSS-класс для выпадающего блока                            |
+| [`onDropdownOpen?`](#управление-состоянием-выподающего-списка)          | `(open: boolean) => void;`                             | -                         | Событие срабатывает при открытии списка                                   |
+| [`dropdownOpen?` ](#управление-состоянием-выподающего-списка)           | `boolean`                                              | -                         | Состояние открыт/закрыт выподающего списка                                |
+| [`ignoreOutsideClicksRefs?`](#управление-состоянием-выподающего-списка) | `ReadonlyArray<React.RefObject<HTMLElement>>`          | -                         | Ссылки на элементы с которые нужно игнорировать при кликах вне компонента |
+| `ref?`                                                                  | `React.Ref<HTMLDivElement>`                            | -                         | Ссылка на корневой DOM-элемент компонента                                 |

--- a/src/components/SelectCanary/__stand__/examples/SelectExampleDropdownOpen/SelectExampleDropdownOpen.tsx
+++ b/src/components/SelectCanary/__stand__/examples/SelectExampleDropdownOpen/SelectExampleDropdownOpen.tsx
@@ -1,0 +1,76 @@
+import { AnimateIconSwitcherProvider } from '@consta/icons/AnimateIconSwitcherProvider';
+import { IconArrowDown } from '@consta/icons/IconArrowDown';
+import { withAnimateSwitcherHOC } from '@consta/icons/withAnimateSwitcherHOC';
+import { Example } from '@consta/stand';
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Button } from '##/components/Button';
+import { FieldGroup } from '##/components/FieldGroup';
+import { useFlag } from '##/hooks/useFlag';
+
+import { Select } from '../../..';
+
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const SelectExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <Select
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreOutsideClicksRefs={[buttonRef]}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};

--- a/src/components/SelectCanary/__stand__/examples/SelectExampleIsLoading/SelectExampleIsLoading.tsx
+++ b/src/components/SelectCanary/__stand__/examples/SelectExampleIsLoading/SelectExampleIsLoading.tsx
@@ -1,5 +1,5 @@
 import { Example } from '@consta/stand';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDebounce } from '##/hooks/useDebounce';
 import { useFlag } from '##/hooks/useFlag';
@@ -76,7 +76,10 @@ const useMockLoadData = (
 
 export const SelectExampleIsLoading = () => {
   const [value, setValue] = useState<Item | null>();
-  const [data, isLoading, onDropdownOpen] = useMockLoadData();
+  const [data, isLoading, load] = useMockLoadData();
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
 
   return (
     <Example col={1}>
@@ -88,7 +91,7 @@ export const SelectExampleIsLoading = () => {
         onDropdownOpen={onDropdownOpen}
         isLoading={isLoading}
         virtualScroll
-        onScrollToBottom={onDropdownOpen}
+        onScrollToBottom={load}
       />
     </Example>
   );

--- a/src/components/SelectCanary/helpers.ts
+++ b/src/components/SelectCanary/helpers.ts
@@ -84,7 +84,9 @@ export type SelectProps<
     caption?: string;
     virtualScroll?: boolean;
     onScrollToBottom?: () => void;
-    onDropdownOpen?: () => void;
+    onDropdownOpen?: (isOpen: boolean) => void;
+    dropdownOpen?: boolean;
+    ignoreOutsideClicksRefs?: ReadonlyArray<React.RefObject<HTMLElement>>;
   },
   HTMLDivElement
 > &

--- a/src/components/SelectComponentsCanary/useSelect/useSelect.ts
+++ b/src/components/SelectComponentsCanary/useSelect/useSelect.ts
@@ -74,8 +74,10 @@ export type SelectProps<ITEM, GROUP, MULTIPLE extends boolean> = {
   searchValue?: string;
   onChange: OnChangeProp<ITEM, MULTIPLE>;
   value: ValueProp<ITEM, MULTIPLE>;
-  onDropdownOpen?: () => void;
+  dropdownOpen?: boolean;
+  onDropdownOpen?: (isOpen: boolean) => void;
   onSearchValueChange?: (value: string) => void;
+  ignoreOutsideClicksRefs?: ReadonlyArray<React.RefObject<HTMLElement>>;
 };
 
 export type OptionProps<ITEM> = {
@@ -165,6 +167,8 @@ export function useSelect<ITEM, GROUP, MULTIPLE extends boolean>(
     searchValue: searchValueProp,
     onDropdownOpen,
     onSearchValueChange,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
   } = params;
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -636,7 +640,11 @@ export function useSelect<ITEM, GROUP, MULTIPLE extends boolean>(
 
   useClickOutside({
     isActive: isOpen,
-    ignoreClicksInsideRefs: [dropdownRef, controlRef],
+    ignoreClicksInsideRefs: [
+      dropdownRef,
+      controlRef,
+      ...(ignoreOutsideClicksRefs || []),
+    ],
     handler: () => {
       setOpen(false);
     },
@@ -707,14 +715,16 @@ export function useSelect<ITEM, GROUP, MULTIPLE extends boolean>(
   }, [resolvedSearchValue]);
 
   useEffect(() => {
-    if (isOpen) {
-      onDropdownOpen?.();
-    }
+    onDropdownOpen?.(isOpen);
   }, [isOpen]);
 
   useEffect(() => {
     onSearchValueChangeRef.current?.(searchValue);
   }, [searchValue]);
+
+  useEffect(() => {
+    setOpen(dropdownOpen || false);
+  }, [dropdownOpen]);
 
   return {
     isOpen,

--- a/src/components/SelectComponentsCanary/useSelect/useSelect.ts
+++ b/src/components/SelectComponentsCanary/useSelect/useSelect.ts
@@ -543,15 +543,20 @@ export function useSelect<ITEM, GROUP, MULTIPLE extends boolean>(
       if (item) {
         onChange(e, item);
       }
+    } else {
+      setOpen(true);
     }
   };
 
-  const Escape = (): void => {
+  const Escape: KeyHandler = (): void => {
     setOpen(false);
   };
 
-  const Tab = (): void => {
-    setOpen(false);
+  const Tab: KeyHandler = (_, e): void => {
+    if (isOpen) {
+      e.preventDefault();
+      setOpen(false);
+    }
   };
 
   const Backspace: KeyHandler = (_, e): void => {

--- a/src/components/UserSelectCanary/UserSelectCanary.tsx
+++ b/src/components/UserSelectCanary/UserSelectCanary.tsx
@@ -96,6 +96,8 @@ const UserSelectRender = <
     onSearchValueChange,
     onDropdownOpen,
     virtualScroll,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
     ...restProps
   } = usePropsHandler(COMPONENT_NAME, withDefaultGetters(props), controlRef);
 
@@ -148,6 +150,8 @@ const UserSelectRender = <
     searchFunction: searchFunction || searchFunctionDefault,
     onSearchValueChange,
     onDropdownOpen,
+    dropdownOpen,
+    ignoreOutsideClicksRefs,
   });
 
   const inputId = id ? `${id}-input` : id;

--- a/src/components/UserSelectCanary/UserSelectCanary.tsx
+++ b/src/components/UserSelectCanary/UserSelectCanary.tsx
@@ -290,6 +290,7 @@ const UserSelectRender = <
               <button
                 type="button"
                 onClick={clearValue}
+                tabIndex={-1}
                 className={cnSelect('ClearIndicator', [cnMixFocus()])}
               >
                 <IconClose

--- a/src/components/UserSelectCanary/__stand__/UserSelect.dev.stand.mdx
+++ b/src/components/UserSelectCanary/__stand__/UserSelect.dev.stand.mdx
@@ -27,6 +27,7 @@ import {
   UserSelectExampleLabelIcon,
 } from './examples/UserSelectExampleLabel/UserSelectExampleLabel';
 import { UserSelectExampleStatus } from './examples/UserSelectExampleStatus/UserSelectExampleStatus';
+import { UserSelectExampleDropdownOpen } from './examples/UserSelectExampleDropdownOpen/UserSelectExampleDropdownOpen';
 
 ```tsx
 import { UserSelect } from '@consta/uikit/UserSelect';
@@ -52,6 +53,7 @@ import { UserSelect } from '@consta/uikit/UserSelect';
 - [Неактивный выпадающий список](#неактивный-выпадающий-список)
 - [Поиск](#поиск)
 - [Создание новых пользователей](#создание-новых-пользователей)
+- [Управление состоянием выподающего списка](#управление-состоянием-выподающего-списка)
 - [Кастомизация](#кастомизация)
   - [Кастомный элемент списка](#кастомный-элемент-списка)
   - [Кастомное выбранное значение](#кастомное-выбранное-значение)
@@ -810,7 +812,10 @@ const useMockLoadData = (
 export const UserSelectExampleIsLoading = () => {
   const [value, setValue] = useState<Item[] | null>();
   const [searchValue, setSearchValue] = useState<string>('');
-  const [data, isLoading, onDropdownOpen] = useMockLoadData(searchValue);
+  const [data, isLoading, load] = useMockLoadData(searchValue);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
 
   return (
     <UserSelect
@@ -822,7 +827,7 @@ export const UserSelectExampleIsLoading = () => {
       onDropdownOpen={onDropdownOpen}
       isLoading={isLoading}
       virtualScroll
-      onScrollToBottom={searchValue ? undefined : onDropdownOpen}
+      onScrollToBottom={searchValue ? undefined : load}
       searchFunction={() => true}
       onSearchValueChange={setSearchValue}
     />
@@ -957,6 +962,148 @@ export function UserSelectExampleCreate() {
 ```
 
 <UserSelectExampleCreateCustomLabel />
+
+## Управление состоянием выподающего списка
+
+Для управлением состояния выподающего списка используйте следующие свойства:
+
+- `dropdownOpen` - флаг открыт/закрыт
+- `onDropdownOpen` - колбек отрабатывающий каждый раз при открытии/закрытии
+- `ignoreClicksInsideRefs` - список ссылок на элементы по которым игнорируется клики
+
+```tsx
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const UserSelectExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <AnimateIconSwitcherProvider active={open}>
+      <FieldGroup>
+        <Button
+          ref={buttonRef}
+          label={open ? 'Закрыть' : 'Открыть'}
+          onClick={setOpen.toggle}
+          iconLeft={Icon}
+          onlyIcon
+        />
+        <UserSelect
+          inputRef={inputRef}
+          placeholder="Выберите вариант"
+          items={items}
+          value={value}
+          onChange={setValue}
+          dropdownOpen={open}
+          onDropdownOpen={onDropdownOpen}
+          ignoreClicksInsideRefs={[buttonRef]}
+        />
+      </FieldGroup>
+    </AnimateIconSwitcherProvider>
+  );
+};
+```
+
+<UserSelectExampleDropdownOpen />
+
+```tsx
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+});
+
+export const UserSelectExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <UserSelect
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreClicksInsideRefs={[buttonRef]}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};
+```
 
 ## Кастомизация
 
@@ -1308,44 +1455,47 @@ export type PropGetGroupKey<GROUP> = (group: GROUP) => string | number;
 export type PropGetGroupLabel<GROUP> = (group: GROUP) => string;
 ```
 
-| Свойство                                                            | Тип или варианты значения                              | По умолчанию                                                  | Описание                                                               |
-| ------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [`view?`](#внешний-вид)                                             | `default` , `clear`                                    | `default`                                                     | Внешний вид компонента                                                 |
-| [`disabled?`](#неактивный-выпадающий-список)                        | `boolean`                                              | -                                                             | Делает компонент неактивным                                            |
-| [`status?`](#статус-поля)                                           | `'', 'alert', 'success', 'warning'`                    | `' '`                                                         | Тип поля                                                               |
-| [`size?`](#размер)                                                  | `'xs'`, `'s'` , `'m'` , `'l'`                          | `'m'`                                                         | Размер компонента                                                      |
-| [`form?`](#форма)                                                   | `default`, `brick`, `round`                            | `default`                                                     | Форма компонента                                                       |
-| [`placeholder?`](#подсказка)                                        | `string`                                               | -                                                             | Подсказка отображается, когда вариант не выбран                        |
-| [`label?`](#лейбл)                                                  | `string`                                               | -                                                             | Лейбл                                                                  |
-| [`labelPosition?`](#лейбл)                                          | `'top', 'left'`                                        | `'top'`                                                       | Положение лейбла по отношению к полю                                   |
-| [`labelIcon?`](#лейбл)                                              | `IconComponent`                                        | -                                                             | Иконка слева от лейбла                                                 |
-| [`caption?`](#подпись)                                              | `string`                                               | -                                                             | Подпись                                                                |
-| [`items`](#варианты)                                                | `ITEM[]`                                               | -                                                             | Варианты                                                               |
-| [`value?`](#выбранное-значение)                                     | `PropValue<ITEM,MULTIPLE>`                             | -                                                             | Выбранное значение                                                     |
-| [`onChange?`](#выбранное-значение)                                  | `PropOnChange<ITEM,MULTIPLE>`                          | -                                                             | Обработчик события изменения значения компонента                       |
-| [`multiple?`](#несколько-вариантов)                                 | `boolean`                                              | `fasle`                                                       | Показывает, что можно выбрать несколько вариантов                      |
-| [`groups?`](#группы-вариантов)                                      | `GROUP[]`                                              | -                                                             | Группы                                                                 |
-| [`searchFunction?`](#поиск)                                         | `PropSearchFunction<ITEM>`                             | поиск по `label` элементов, `label` получен из `getItemLabel` | Функция поиска                                                         |
-| [`renderItem?`](#кастомный-элемент-списка)                          | `PropRenderItem<ITEM>`                                 | рендер по умолчанию                                           | Рендер-функция для элемента списка                                     |
-| [`renderValue?`](#кастомное-выбранное-значение)                     | `PropRenderValue<ITEM>`                                | рендер по умолчанию                                           | Рендер-функция для элемента выбранного значения                        |
-| [`getItemLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)     | `PropGetItemLabel<ITEM>`                               | `(item) => item.label`                                        | Функция для определения названия элемента                              |
-| [`getItemKey?`](#кастомные-типы-данных-для-групп-и-вариантов)       | `PropGetItemKey<ITEM>`                                 | `(item) => item.id`                                           | Функция для определения уникального ключа элемента                     |
-| [`getItemSubLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)  | `PropGetItemSubLabel<ITEM>`                            | `(item) => item.subLabel`                                     | Функция для определения подписи элемента                               |
-| [`getItemAvatarUrl?`](#кастомные-типы-данных-для-групп-и-вариантов) | `PropGetItemAvatarUrl<ITEM>`                           | `(item) => item.avatarUrl`                                    | Функция для определения аватарки элемента                              |
-| [`getItemGroupKey?`](#кастомные-типы-данных-для-групп-и-вариантов)  | `PropGetItemGroupKey<ITEM>`                            | `(item) => item.groupId`                                      | Функция для определения ключа группы, к которой будет привязан элемент |
-| [`getItemDisabled?`](#кастомные-типы-данных-для-групп-и-вариантов)  | `PropGetItemDisabled<ITEM>`                            | `(item) => item.disabled`                                     | Функция для определения состояния `disabled`                           |
-| [`getGroupLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)    | `PropGetGroupKey<GROUP>`                               | `(group) => group.id`                                         | Функция для определения названия группы                                |
-| [`getGroupKey?`](#кастомные-типы-данных-для-групп-и-вариантов)      | `PropGetGroupLabel<GROUP>`                             | `(group) => group.label`                                      | Функция для определения уникального ключа группы                       |
-| `isLoading?`                                                        | `boolean`                                              | -                                                             | При `true` будет отображаться лоудер загрузки                          |
-| `required?`                                                         | `boolean`                                              | -                                                             | Нужно заполнить                                                        |
-| `searchValue?`                                                      | `string`                                               | -                                                             | Значение поля ввода                                                    |
-| `labelForEmptyItems?`                                               | `string`                                               | `Список пуст`                                                 | Текст для случая, когда в списке нет значений                          |
-| [`labelForNotFound?`](#поиск)                                       | `string`                                               | `Не найдено`                                                  | Текст для случая, когда при поиске ничего не нашлось                   |
-| [`labelForCreate?`](#создание-новых-пользователей)                  | `string`                                               | `+`                                                           | Текст для кнопки, по которой можно добавить пользователя в список      |
-| `onBlur?`                                                           | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                                                             | Обработчик события `blur`                                              |
-| `onFocus?`                                                          | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                                                             | Обработчик события `focus`                                             |
-| `ariaLabel?`                                                        | `string`                                               | -                                                             | `aria` атрибут для поля ввода                                          |
-| `name?`                                                             | `string`                                               | -                                                             | Имя поля ввода                                                         |
-| `className?`                                                        | `string`                                               | -                                                             | Дополнительный CSS-класс                                               |
-| `dropdownClassName?`                                                | `string`                                               | -                                                             | Дополнительный CSS-класс для выпадающего блока                         |
-| `ref?`                                                              | `React.Ref<HTMLDivElement>`                            | -                                                             | Ссылка на корневой DOM-элемент компонента                              |
+| Свойство                                                                | Тип или варианты значения                              | По умолчанию                                                  | Описание                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [`view?`](#внешний-вид)                                                 | `default` , `clear`                                    | `default`                                                     | Внешний вид компонента                                                    |
+| [`disabled?`](#неактивный-выпадающий-список)                            | `boolean`                                              | -                                                             | Делает компонент неактивным                                               |
+| [`status?`](#статус-поля)                                               | `'', 'alert', 'success', 'warning'`                    | `' '`                                                         | Тип поля                                                                  |
+| [`size?`](#размер)                                                      | `'xs'`, `'s'` , `'m'` , `'l'`                          | `'m'`                                                         | Размер компонента                                                         |
+| [`form?`](#форма)                                                       | `default`, `brick`, `round`                            | `default`                                                     | Форма компонента                                                          |
+| [`placeholder?`](#подсказка)                                            | `string`                                               | -                                                             | Подсказка отображается, когда вариант не выбран                           |
+| [`label?`](#лейбл)                                                      | `string`                                               | -                                                             | Лейбл                                                                     |
+| [`labelPosition?`](#лейбл)                                              | `'top', 'left'`                                        | `'top'`                                                       | Положение лейбла по отношению к полю                                      |
+| [`labelIcon?`](#лейбл)                                                  | `IconComponent`                                        | -                                                             | Иконка слева от лейбла                                                    |
+| [`caption?`](#подпись)                                                  | `string`                                               | -                                                             | Подпись                                                                   |
+| [`items`](#варианты)                                                    | `ITEM[]`                                               | -                                                             | Варианты                                                                  |
+| [`value?`](#выбранное-значение)                                         | `PropValue<ITEM,MULTIPLE>`                             | -                                                             | Выбранное значение                                                        |
+| [`onChange?`](#выбранное-значение)                                      | `PropOnChange<ITEM,MULTIPLE>`                          | -                                                             | Обработчик события изменения значения компонента                          |
+| [`multiple?`](#несколько-вариантов)                                     | `boolean`                                              | `fasle`                                                       | Показывает, что можно выбрать несколько вариантов                         |
+| [`groups?`](#группы-вариантов)                                          | `GROUP[]`                                              | -                                                             | Группы                                                                    |
+| [`searchFunction?`](#поиск)                                             | `PropSearchFunction<ITEM>`                             | поиск по `label` элементов, `label` получен из `getItemLabel` | Функция поиска                                                            |
+| [`renderItem?`](#кастомный-элемент-списка)                              | `PropRenderItem<ITEM>`                                 | рендер по умолчанию                                           | Рендер-функция для элемента списка                                        |
+| [`renderValue?`](#кастомное-выбранное-значение)                         | `PropRenderValue<ITEM>`                                | рендер по умолчанию                                           | Рендер-функция для элемента выбранного значения                           |
+| [`getItemLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)         | `PropGetItemLabel<ITEM>`                               | `(item) => item.label`                                        | Функция для определения названия элемента                                 |
+| [`getItemKey?`](#кастомные-типы-данных-для-групп-и-вариантов)           | `PropGetItemKey<ITEM>`                                 | `(item) => item.id`                                           | Функция для определения уникального ключа элемента                        |
+| [`getItemSubLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)      | `PropGetItemSubLabel<ITEM>`                            | `(item) => item.subLabel`                                     | Функция для определения подписи элемента                                  |
+| [`getItemAvatarUrl?`](#кастомные-типы-данных-для-групп-и-вариантов)     | `PropGetItemAvatarUrl<ITEM>`                           | `(item) => item.avatarUrl`                                    | Функция для определения аватарки элемента                                 |
+| [`getItemGroupKey?`](#кастомные-типы-данных-для-групп-и-вариантов)      | `PropGetItemGroupKey<ITEM>`                            | `(item) => item.groupId`                                      | Функция для определения ключа группы, к которой будет привязан элемент    |
+| [`getItemDisabled?`](#кастомные-типы-данных-для-групп-и-вариантов)      | `PropGetItemDisabled<ITEM>`                            | `(item) => item.disabled`                                     | Функция для определения состояния `disabled`                              |
+| [`getGroupLabel?`](#кастомные-типы-данных-для-групп-и-вариантов)        | `PropGetGroupKey<GROUP>`                               | `(group) => group.id`                                         | Функция для определения названия группы                                   |
+| [`getGroupKey?`](#кастомные-типы-данных-для-групп-и-вариантов)          | `PropGetGroupLabel<GROUP>`                             | `(group) => group.label`                                      | Функция для определения уникального ключа группы                          |
+| `isLoading?`                                                            | `boolean`                                              | -                                                             | При `true` будет отображаться лоудер загрузки                             |
+| `required?`                                                             | `boolean`                                              | -                                                             | Нужно заполнить                                                           |
+| `searchValue?`                                                          | `string`                                               | -                                                             | Значение поля ввода                                                       |
+| `labelForEmptyItems?`                                                   | `string`                                               | `Список пуст`                                                 | Текст для случая, когда в списке нет значений                             |
+| [`labelForNotFound?`](#поиск)                                           | `string`                                               | `Не найдено`                                                  | Текст для случая, когда при поиске ничего не нашлось                      |
+| [`labelForCreate?`](#создание-новых-пользователей)                      | `string`                                               | `+`                                                           | Текст для кнопки, по которой можно добавить пользователя в список         |
+| `onBlur?`                                                               | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                                                             | Обработчик события `blur`                                                 |
+| `onFocus?`                                                              | `(event?: React.FocusEvent<HTMLInputElement>) => void` | -                                                             | Обработчик события `focus`                                                |
+| `ariaLabel?`                                                            | `string`                                               | -                                                             | `aria` атрибут для поля ввода                                             |
+| `name?`                                                                 | `string`                                               | -                                                             | Имя поля ввода                                                            |
+| `className?`                                                            | `string`                                               | -                                                             | Дополнительный CSS-класс                                                  |
+| `dropdownClassName?`                                                    | `string`                                               | -                                                             | Дополнительный CSS-класс для выпадающего блока                            |
+| [`onDropdownOpen?`](#управление-состоянием-выподающего-списка)          | `(open: boolean) => void;`                             | -                                                             | Событие срабатывает при открытии списка                                   |
+| [`dropdownOpen?` ](#управление-состоянием-выподающего-списка)           | `boolean`                                              | -                                                             | Состояние открыт/закрыт выподающего списка                                |
+| [`ignoreOutsideClicksRefs?`](#управление-состоянием-выподающего-списка) | `ReadonlyArray<React.RefObject<HTMLElement>>`          | -                                                             | Ссылки на элементы с которые нужно игнорировать при кликах вне компонента |
+| `ref?`                                                                  | `React.Ref<HTMLDivElement>`                            | -                                                             | Ссылка на корневой DOM-элемент компонента                                 |

--- a/src/components/UserSelectCanary/__stand__/examples/UserSelectExampleDropdownOpen/UserSelectExampleDropdownOpen.tsx
+++ b/src/components/UserSelectCanary/__stand__/examples/UserSelectExampleDropdownOpen/UserSelectExampleDropdownOpen.tsx
@@ -1,0 +1,77 @@
+import { AnimateIconSwitcherProvider } from '@consta/icons/AnimateIconSwitcherProvider';
+import { IconArrowDown } from '@consta/icons/IconArrowDown';
+import { withAnimateSwitcherHOC } from '@consta/icons/withAnimateSwitcherHOC';
+import { Example } from '@consta/stand';
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Button } from '##/components/Button';
+import { FieldGroup } from '##/components/FieldGroup';
+import { useFlag } from '##/hooks/useFlag';
+
+import { UserSelect } from '../../..';
+
+type Item = {
+  label: string;
+  id: number | string;
+};
+
+const items: Item[] = [
+  {
+    label: 'Первый',
+    id: 1,
+  },
+  {
+    label: 'Второй',
+    id: 2,
+  },
+  {
+    label: 'Третий',
+    id: 3,
+  },
+];
+
+const Icon = withAnimateSwitcherHOC({
+  startIcon: IconArrowDown,
+  startDirection: 0,
+  endDirection: 180,
+  transition: 180,
+});
+
+export const UserSelectExampleDropdownOpen = () => {
+  const [value, setValue] = useState<Item | null>();
+  const [open, setOpen] = useFlag();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    setOpen.set(open);
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <Example col={1}>
+      <AnimateIconSwitcherProvider active={open}>
+        <FieldGroup>
+          <Button
+            ref={buttonRef}
+            label={open ? 'Закрыть' : 'Открыть'}
+            onClick={setOpen.toggle}
+            iconLeft={Icon}
+            onlyIcon
+          />
+          <UserSelect
+            inputRef={inputRef}
+            placeholder="Выберите вариант"
+            items={items}
+            value={value}
+            onChange={setValue}
+            dropdownOpen={open}
+            onDropdownOpen={onDropdownOpen}
+            ignoreOutsideClicksRefs={[buttonRef]}
+          />
+        </FieldGroup>
+      </AnimateIconSwitcherProvider>
+    </Example>
+  );
+};

--- a/src/components/UserSelectCanary/__stand__/examples/UserSelectExampleIsLoading/UserSelectExampleIsLoading.tsx
+++ b/src/components/UserSelectCanary/__stand__/examples/UserSelectExampleIsLoading/UserSelectExampleIsLoading.tsx
@@ -1,5 +1,5 @@
 import { Example } from '@consta/stand';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDebounce } from '##/hooks/useDebounce';
 import { useFlag } from '##/hooks/useFlag';
@@ -77,7 +77,10 @@ const useMockLoadData = (
 export const UserSelectExampleIsLoading = () => {
   const [value, setValue] = useState<Item[] | null>();
   const [searchValue, setSearchValue] = useState<string>('');
-  const [data, isLoading, onDropdownOpen] = useMockLoadData(searchValue);
+  const [data, isLoading, load] = useMockLoadData(searchValue);
+  const onDropdownOpen = useCallback((open: boolean) => {
+    open && load();
+  }, []);
 
   return (
     <Example col={1}>
@@ -90,7 +93,7 @@ export const UserSelectExampleIsLoading = () => {
         onDropdownOpen={onDropdownOpen}
         isLoading={isLoading}
         virtualScroll
-        onScrollToBottom={searchValue ? undefined : onDropdownOpen}
+        onScrollToBottom={searchValue ? undefined : load}
         searchFunction={() => true}
         onSearchValueChange={setSearchValue}
       />

--- a/src/components/UserSelectCanary/helpers.ts
+++ b/src/components/UserSelectCanary/helpers.ts
@@ -109,7 +109,9 @@ export type UserSelectProps<
     virtualScroll?: boolean;
     onScrollToBottom?: () => void;
     onSearchValueChange?: (value: string) => void;
-    onDropdownOpen?: () => void;
+    onDropdownOpen?: (isOpen: boolean) => void;
+    dropdownOpen?: boolean;
+    ignoreOutsideClicksRefs?: ReadonlyArray<React.RefObject<HTMLElement>>;
   },
   HTMLDivElement
 > &

--- a/src/hooks/useFlag/useFlag.ts
+++ b/src/hooks/useFlag/useFlag.ts
@@ -8,6 +8,7 @@ type Flag = [
     on: () => void;
     off: () => void;
     toggle: () => void;
+    set: (flag: boolean) => void;
     /**
      * @deprecated since version 4.6.3 toggle()
      */
@@ -29,6 +30,7 @@ export const useFlag = (initial = false): Flag => {
       on,
       off,
       toggle,
+      set: setState,
       toogle,
     },
   ];

--- a/src/icons/createIcon/createIcon.tsx
+++ b/src/icons/createIcon/createIcon.tsx
@@ -1,6 +1,5 @@
-import React, { forwardRef } from 'react';
-
-import { cnIcon, Icon, IconProps } from '../Icon/Icon';
+import { createIcon as iconsCreateIcon } from '@consta/icons/Icon';
+import React from 'react';
 
 type SizeComponent = React.FC<React.SVGProps<SVGSVGElement>>;
 type CreateIconArguments = {
@@ -10,37 +9,6 @@ type CreateIconArguments = {
   name: string;
 };
 
-function getSvgBySize(
-  size: IconProps['size'] | undefined,
-  m: SizeComponent,
-  s: SizeComponent,
-  xs: SizeComponent,
-) {
-  switch (size) {
-    case 'xs':
-      return xs;
-    case 's':
-      return s;
-    case 'm':
-      return m;
-    default:
-      return m;
-  }
-}
-
-export function createIcon({ m, s, xs, name }: CreateIconArguments) {
-  const IconComponent = forwardRef<HTMLSpanElement, IconProps>((props, ref) => {
-    const Svg = getSvgBySize(props.size, m, s, xs);
-    return (
-      <Icon
-        {...props}
-        className={cnIcon(null, [name, props.className])}
-        ref={ref}
-      >
-        <Svg className={cnIcon('Svg')} />
-      </Icon>
-    );
-  });
-
-  return IconComponent;
+export function createIcon(props: CreateIconArguments) {
+  return iconsCreateIcon({ ...props, l: props.m });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,6 +1733,11 @@
   resolved "https://registry.yarnpkg.com/@consta/icons/-/icons-0.7.0.tgz#3598732b9ec5a22d586f8eb06c38603e86e74576"
   integrity sha512-+z96Ams4ZnOeZtNhsVQpsarlpmv7wNDA+sfu3AVvAP0h+K7zCPU7BYcQppek71najQkxqpsngjznB7G8IbA4RA==
 
+"@consta/icons@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@consta/icons/-/icons-0.9.0.tgz#6f5af9e85176b545c9032ffd0fbfa0386e08dae3"
+  integrity sha512-a8etwnWHbiKSUirXPD1pAKt+jdYmP1wexn2tLsIQRUNPlZdvUDmq0gpWOKh6TrEW2AThn4ClYPfgefkFyzcjfw==
+
 "@consta/stand@^0.0.118":
   version "0.0.118"
   resolved "https://registry.yarnpkg.com/@consta/stand/-/stand-0.0.118.tgz#eab08843be7aeab70c5971247f25e40caf395395"


### PR DESCRIPTION
Добавили свойства для управления выподающего списка:
1) dropdownOpen
2) dropdownOnOpen
3) ignoreOutsideClicksRefs

Доработали управление с клавиатуры:
По фокусу на поле ввода список не должен открываться, подсвечивается поле
При фокусе и закрытом списке по Enter, список открывается
При фокусе и закрытом списке по нажатию стрелочек вверх и вниз список открывается
При фокусе и открытом списке по нажатию Esc список должен закрываться
При фокусе и закрытом списке по нажатию Tab список должен закрываться, и фокус должен оставаться на поле ввода

closed #3090
