### PR TITLE
fix(List): fixed dafault color of list items in dark theme

### DIFF
--- a/src/components/ListCanary/ListItem/ListItem.tsx
+++ b/src/components/ListCanary/ListItem/ListItem.tsx
@@ -2,7 +2,7 @@ import './ListItem.css';
 
 import React, { forwardRef } from 'react';
 
-import { cnText } from '##/components/Text';
+import { cnText, textPropViewDefault } from '##/components/Text';
 import { cnMixSpace } from '##/mixs/MixSpace';
 import { cn } from '##/utils/bem';
 
@@ -38,7 +38,7 @@ const ListItemRender = (
     as: Tag = 'div',
     checked,
     onClick,
-    status,
+    status = textPropViewDefault,
     space,
     iconSize,
     ...otherProps


### PR DESCRIPTION
Fixed problem that causes Combobox, ContextMenu, Select list items to have wrong text/icon colors with dark theme by adding default value to status property;

fix #3317

## Описание изменений
Добавил дефолтное значение для пропсы status компоненту ListItem у ListCanary, что бы при не заданном свойстве для текста подставлялся css класс `Text_view_primary` по-умолчанию

## Чек-лист

- [x] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
