### PR TITLE
feat(hooks):add block body scroll hook

### DIFF
--- a/src/hooks/useBlockBodyScroll/index.ts
+++ b/src/hooks/useBlockBodyScroll/index.ts
@@ -1,0 +1,1 @@
+export {} from './useBlockBodyScroll';

--- a/src/hooks/useBlockBodyScroll/useBlockBodyScroll.ts
+++ b/src/hooks/useBlockBodyScroll/useBlockBodyScroll.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from 'react';
+
+const getBodyElement = () => window.document.body;
+const getScrollBarWidth = () => {
+  return window.innerWidth - document.body.offsetWidth;
+};
+
+export const useBlockBodyScroll = () => {
+  useLayoutEffect(() => {
+    const body = getBodyElement();
+    const defaultOverflow = body.style.overflow;
+    const defaultPaddingRight = body.style.paddingRight;
+    const scrollBarWidth = getScrollBarWidth();
+
+    body.style.overflow = 'hidden';
+    body.style.paddingRight = `${scrollBarWidth}px`;
+
+    return () => {
+      body.style.overflow = defaultOverflow;
+      body.style.paddingRight = defaultPaddingRight;
+    };
+  }, []);
+};


### PR DESCRIPTION
## Описание изменений
Добавлен хук useBodyScrollBlock - для отключения скрола на body, при открытии модальных окон

При открытии компонентов Modal или Sidebar, не блокируется скрол на body 
Из-за этого, когда в Modal (Sidebar) компоненте, много контента и появляется внутренний скрол, можно проскролить контент не там где ожидается

Демка - 
https://codesandbox.io/p/sandbox/relaxed-blackburn-mzs7sy?file=%2Fsrc%2FModal.tsx%3A11%2C37

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
