### PR TITLE
fix(Table): Добавлена предобработка пользовательского ввода

### DIFF
--- a/src/components/Table/TextFilter/TableTextFilter.tsx
+++ b/src/components/Table/TextFilter/TableTextFilter.tsx
@@ -27,6 +27,11 @@ type TableTextFilterProps = FilterComponentProps & {
   emptySearchText?: string;
 };
 
+const sanitizeRegex = (futureRegex: string): string =>
+  futureRegex
+    .replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replaceAll(/\$/g, '$$$$');
+
 export const TableTextFilter: React.FC<TableTextFilterProps> = ({
   items = [],
   withSearch = false,
@@ -56,7 +61,7 @@ export const TableTextFilter: React.FC<TableTextFilterProps> = ({
     }
 
     return items.filter(({ name }) => {
-      return name.match(new RegExp(`${searchValue}`, 'i'));
+      return name.match(new RegExp(sanitizeRegex(searchValue), 'i'));
     });
   }, [searchValue, items]);
 

--- a/src/components/Table/__tests__/Table.test.tsx
+++ b/src/components/Table/__tests__/Table.test.tsx
@@ -776,6 +776,20 @@ describe('Компонент Table', () => {
           fireEvent.click(screen.getByRole('button', { name: /отмена/i }));
           expect(getRows()).toHaveLength(3);
         });
+
+        it.each(Array.from('.*+?^${}()|[]\\'))(
+          'При вводе специального символа %s компонент не падает',
+          (regexPart) => {
+            render(<Table {...props} data-testid={testId} />);
+
+            fireEvent.click(getFilterButtons()[0]);
+            fireEvent.change(screen.getByRole('textbox'), {
+              target: { value: regexPart },
+            });
+
+            expect(screen.getByTestId(testId)).toBeInTheDocument();
+          },
+        );
       });
 
       describe('Проверка TableNumberFilter', () => {


### PR DESCRIPTION
## Описание изменений
Пользовательский ввод не проверялся и записывался в регулярное выражение без предобработки. 
Со сторы регулярки * первым символом выглядело как: повтори предыдущий(отсутствующий) символ сколько угодно раз, и так далее.
Теперь ввод экранируется

Написан тест для проверки экранирования

fixes #3654

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
