### PR TITLE
fix(tootip): Добавлен проброс ref в Transition

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,8 +1,9 @@
 import './Tooltip.css';
 
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { Transition } from 'react-transition-group';
 
+import { useForkRef } from '##/hooks/useForkRef';
 import { animateTimeout, cnMixPopoverAnimate } from '##/mixs/MixPopoverAnimate';
 import { cnMixPopoverArrow } from '##/mixs/MixPopoverArrow/MixPopoverArrow';
 import { cn } from '##/utils/bem';
@@ -36,6 +37,9 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       ...otherProps
     } = props;
 
+    const contentRef = useRef(null);
+    const contentForkedRef = useForkRef([contentRef, ref]);
+
     const { theme } = useTheme();
 
     const [direction, setDirection] = useState<Direction | undefined>();
@@ -61,7 +65,12 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     }, [generateDeps(theme), status]);
 
     return (
-      <Transition in={isOpen} unmountOnExit timeout={animateTimeout}>
+      <Transition
+        in={isOpen}
+        unmountOnExit
+        timeout={animateTimeout}
+        nodeRef={contentRef}
+      >
         {(animate) => (
           <ThemeContext.Provider value={value}>
             <Popover
@@ -69,7 +78,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               arrowOffset={ARROW_OFFSET + ARROW_SIZE}
               offset={ARROW_SIZE + ARROW_OFFSET / 2 + offset}
               onSetDirection={onSetDirection}
-              ref={ref}
+              ref={contentForkedRef}
               className={cnTooltip({ status }, [
                 className,
                 cnMixPopoverAnimate({ animate }),


### PR DESCRIPTION
Есть не передан nodeRef, Transition из react-transition-group делает fallback на deprecated React API (findDOMNode(this)), то есть пытается получить своих children-ов

fixes #3668

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
