### PR TITLE
feat(badge): add transparent badge

### DIFF
--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -121,6 +121,17 @@
         --badge-text-color: var(--color-typo-system);
       }
     }
+
+    &_transparent {
+      --opacity: 0.1;
+      color: var(--badge-text-color);
+      background: rgb(from var(--badge-bg-color) r g b / var(--opacity));
+
+      &.Badge_status_system {
+        --opacity: 0.3;
+        --badge-text-color: var(--color-typo-secondary);
+      }
+    }
   }
 
   &_counter {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -12,7 +12,7 @@ export const badgePropSize = ['xs', 's', 'm', 'l'] as const;
 export type BadgePropSize = typeof badgePropSize[number];
 export const badgePropSizeDefault: BadgePropSize = 'm';
 
-export const badgePropView = ['filled', 'stroked'] as const;
+export const badgePropView = ['filled', 'stroked', 'transparent'] as const;
 export type BadgePropView = typeof badgePropView[number];
 export const badgePropViewDefault: BadgePropView = badgePropView[0];
 

--- a/src/components/Badge/__stand__/Badge.dev.stand.mdx
+++ b/src/components/Badge/__stand__/Badge.dev.stand.mdx
@@ -93,9 +93,12 @@ import { Badge } from '@consta/uikit/Badge';
 
 `stroked` — второстепенный, такой бейдж не будет так сильно бросаться в глаза.
 
+`transparent` — промежуточный между двумя предыдущими. Позволяет подсветить статус, но не акцентировать на нем внимание.
+
 ```ts
 <Badge view="filled" label="Filled badge" />
 <Badge view="stroked" label="Stroked badge" />
+<Badge view="transparent" label="Transparent badge" />
 ```
 
 <BadgeExampleView />
@@ -134,7 +137,7 @@ import { Badge } from '@consta/uikit/Badge';
 | Свойство                           | Тип                                                     | По умолчанию | Описание                                                         |
 | ---------------------------------- | ------------------------------------------------------- | ------------ | ---------------------------------------------------------------- |
 | [`size?`](#размер)                 | `'s' , 'm' , 'l'`                                       | `'m'`        | Размер                                                           |
-| [`view?`](#типы-бейджиков)         | `'filled' , 'stroked'`                                  | `'filled'`   | Вид                                                              |
+| [`view?`](#типы-бейджиков)         | `'filled' , 'stroked', 'transparent'`                   | `'filled'`   | Вид                                                              |
 | [`status?`](#статус-и-содержимое)  | `'success' , 'error' , 'warning' , 'normal' , 'system'` | `'normal'`   | Статус                                                           |
 | [`form?`](#форма)                  | `'default' , 'round'`                                   | `'default'`  | Форма                                                            |
 | [`minified?`](#типы-бейджиков)     | `boolean`                                               | -            | Отвечает за отрисовку бейджика без надписи, в виде точки         |

--- a/src/components/Badge/__stand__/examples/BadgeExampleView/BadgeExampleView.tsx
+++ b/src/components/Badge/__stand__/examples/BadgeExampleView/BadgeExampleView.tsx
@@ -7,5 +7,6 @@ export const BadgeExampleView = () => (
   <Example>
     <Badge view="filled" label="Filled badge" />
     <Badge view="stroked" label="Stroked badge" />
+    <Badge view="transparent" label="Transparent badge" />
   </Example>
 );

--- a/src/components/BadgeGroup/__stand__/BadgeGroup.dev.stand.mdx
+++ b/src/components/BadgeGroup/__stand__/BadgeGroup.dev.stand.mdx
@@ -1,4 +1,4 @@
-import { MdxMenu } from '@consta/stand';
+import { MdxMenu, MdxTabs } from '@consta/stand';
 import { BadgeGroupExampleSize } from './examples/BadgeGroupExampleSize/BadgeGroupExampleSize';
 import { BadgeGroupExampleForm } from './examples/BadgeGroupExampleForm/BadgeGroupExampleForm';
 import { BadgeGroupExampleItems } from './examples/BadgeGroupExampleItems/BadgeGroupExampleItems';
@@ -36,6 +36,8 @@ import { Badge } from '@consta/uikit/Badge';
 - HTML-тег — в поле `as` или с помощью функции `getItemAs`,
 - дополнительные атрибуты — в поле `attributes` или с помощью функции `getItemAttributes`,
 
+<MdxTabs>
+
 ```tsx
 import React from 'react';
 
@@ -55,6 +57,7 @@ const items: Item[] = [
   },
   {
     text: 'ожидает',
+    form: 'transparent',
     color: 'warning',
   },
   {
@@ -91,6 +94,8 @@ export const BadgeGroupExampleItems = () => {
 ```
 
 <BadgeGroupExampleItems />
+
+</MdxTabs>
 
 ## Внешний вид
 

--- a/src/components/BadgeGroup/__stand__/BadgeGroup.variants.tsx
+++ b/src/components/BadgeGroup/__stand__/BadgeGroup.variants.tsx
@@ -34,6 +34,7 @@ const badges: BadgeGroupDefaultItem[] = [
     iconLeft: IconQuestion,
     iconRight: IconAlert,
     label: 'ожидает',
+    view: 'transparent',
     status: 'warning',
   },
   {

--- a/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleBasic/BadgeGroupExampleBasic.tsx
+++ b/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleBasic/BadgeGroupExampleBasic.tsx
@@ -16,6 +16,7 @@ const badges: BadgeGroupDefaultItem[] = [
     key: '2',
     label: 'ожидает',
     status: 'warning',
+    view: 'transparent',
   },
   {
     key: '3',

--- a/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleFitMode/BadgeGroupExampleFitMode.tsx
+++ b/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleFitMode/BadgeGroupExampleFitMode.tsx
@@ -13,6 +13,7 @@ const items: BadgeGroupDefaultItem[] = [
     key: 2,
     label: 'ожидает',
     status: 'warning',
+    view: 'transparent',
   },
   {
     key: 3,

--- a/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleForm/BadgeGroupExampleForm.tsx
+++ b/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleForm/BadgeGroupExampleForm.tsx
@@ -14,6 +14,7 @@ const items: BadgeGroupDefaultItem[] = [
     key: 2,
     label: 'ожидает',
     status: 'warning',
+    view: 'transparent',
   },
   {
     key: 3,

--- a/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleItems/BadgeGroupExampleItems.tsx
+++ b/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleItems/BadgeGroupExampleItems.tsx
@@ -18,6 +18,7 @@ const items: Item[] = [
   {
     text: 'ожидает',
     color: 'warning',
+    form: 'transparent',
   },
   {
     text: 'новый',

--- a/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleSize/BadgeGroupExampleSize.tsx
+++ b/src/components/BadgeGroup/__stand__/examples/BadgeGroupExampleSize/BadgeGroupExampleSize.tsx
@@ -14,6 +14,7 @@ const items: BadgeGroupDefaultItem[] = [
     key: 2,
     label: 'ожидает',
     status: 'warning',
+    view: 'transparent',
   },
   {
     key: 3,


### PR DESCRIPTION
## Описание изменений
Из интересного то, что прозрачность вычисляется не на уровне препроцессора, а на уровне браузера, как об этом писалось в #3707. Единственное что, color показалась более общей, поскольку она оперирует цветовыми пространствами. Достаточным показался синтаксис rgb в относительных единицах

Обновлена документация, добавлены прозрачные бейджи в примеры. Возможно стоит обновить текст документации для нового типа бейджей

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
