### PR TITLE
feat(Tooltip): adds container prop

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -35,6 +35,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       className,
       children,
       viewportRef,
+      container,
       ...otherProps
     } = props;
 
@@ -81,6 +82,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               onSetDirection={onSetDirection}
               ref={contentForkedRef}
               viewportRef={viewportRef}
+              container={container}
               className={cnTooltip({ status }, [
                 className,
                 cnMixPopoverAnimate({ animate }),

--- a/src/components/Tooltip/__stand__/Tooltip.dev.stand.mdx
+++ b/src/components/Tooltip/__stand__/Tooltip.dev.stand.mdx
@@ -233,6 +233,7 @@ import { Tooltip } from '@consta/uikit/Tooltip';
 | `onClickOutside?`     | `(event: MouseEvent) => void`                 | -                       | см. [Popover](##LIBS.LIB.STAND.TAB/lib:uikit/stand:components-popover-stable/tab:dev)                                 |
 | `offset?`             | `number`                                      | `0`                     | Отступ от якоря или позиции                                                                                           |
 | `equalAnchorWidth?`   | `boolean`                                     | `false`                 | см. [Popover](##LIBS.LIB.STAND.TAB/lib:uikit/stand:components-popover-stable/tab:dev)                                 |
+| `container?`          | `Element`                                     | `window.document.body`  | см. [Popover](##LIBS.LIB.STAND.TAB/lib:uikit/stand:components-popover-stable/tab:dev)                                 |
 
 ### Пример
 

--- a/src/components/Tooltip/types.ts
+++ b/src/components/Tooltip/types.ts
@@ -30,5 +30,6 @@ export type TooltipProps = PropsWithJsxAttributes<
     offset?: number;
     onSetDirection?: (direction: Direction) => void;
     viewportRef?: React.RefObject<HTMLElement>;
+    container?: Element;
   } & PositioningProps
 >;


### PR DESCRIPTION
## Описание изменений
closes #3899. Прокинул проп `container` из `Tooltip` в `Popover`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
