### PR TITLE
fix(UserSelect): исправление обрезания ФИО значения

### DIFF
--- a/src/components/UserSelect/UserSelect.tsx
+++ b/src/components/UserSelect/UserSelect.tsx
@@ -257,7 +257,7 @@ const UserSelectRender = <
         view={view}
         type="userselect"
         form={form}
-        multiple={multiple}
+        multiple
         ref={ref}
         style={style}
         {...restProps}

--- a/src/components/UserSelect/UserSelect.tsx
+++ b/src/components/UserSelect/UserSelect.tsx
@@ -257,7 +257,7 @@ const UserSelectRender = <
         view={view}
         type="userselect"
         form={form}
-        multiple
+        multiple={multiple}
         ref={ref}
         style={style}
         {...restProps}

--- a/src/components/UserSelect/UserSelectValue/UserSelectValue.css
+++ b/src/components/UserSelect/UserSelectValue/UserSelectValue.css
@@ -4,6 +4,12 @@
     margin-bottom: calc(var(--space-s) / 4);
   }
 
+  &:not(&.UserSelectValue_multiple) {
+    .User-Name {
+      max-width: 100%;
+    }
+  }
+
   &_disabled {
     opacity: 0.6;
   }

--- a/src/components/UserSelect/UserSelectValue/UserSelectValue.css
+++ b/src/components/UserSelect/UserSelectValue/UserSelectValue.css
@@ -4,12 +4,6 @@
     margin-bottom: calc(var(--space-s) / 4);
   }
 
-  &:not(&.UserSelectValue_multiple) {
-    .User-Name {
-      max-width: 100%;
-    }
-  }
-
   &_disabled {
     opacity: 0.6;
   }
@@ -19,6 +13,10 @@
       &:hover {
         background-color: var(--color-control-bg-clear);
       }
+    }
+
+    .User-Name {
+      max-width: 100%;
     }
   }
 }


### PR DESCRIPTION
## Описание изменений

При использовании UserSelect вместе с полными именами вне зависимости от размера контейнера имя обрезается, так же вне зависимости от использования multiply свойства Select всегда использует multiply

До исправлений
<img width="826" alt="image" src="https://github.com/user-attachments/assets/e4bc2e31-fe89-470f-b31f-1dbabfabd601" />


После исправлений
<img width="842" alt="image" src="https://github.com/user-attachments/assets/1020e788-2c3a-447c-9603-45b42feeaf7b" />


## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
