### PR TITLE
fix(DatePicker): исправления багов с disableDates в DatePicker

### DIFF
--- a/src/components/DatePicker/DatePickerTypeDate/DatePickerTypeDate.tsx
+++ b/src/components/DatePicker/DatePickerTypeDate/DatePickerTypeDate.tsx
@@ -122,6 +122,7 @@ export const DatePickerTypeDate: DatePickerTypeComponent<'date'> = forwardRef(
             setCalendarVisible.off();
           }}
           renderAdditionalControls={renderAdditionalControls}
+          disableDates={disableDates}
           zIndex={getDropdownZIndex(props.style)}
           onChangeCurrentVisibleDate={setCurrentVisibleDate}
         />

--- a/src/components/DatePicker/__stand__/DatePicker.variants.tsx
+++ b/src/components/DatePicker/__stand__/DatePicker.variants.tsx
@@ -75,6 +75,7 @@ const Variants = () => {
   const minDate = useDate('minDate', minDateDefault);
   const maxDate = useDate('maxDate', maxDateDefault);
   const withEvents = useBoolean('withEvents', false);
+  const withDisableDates = useBoolean('withDisableDates', false);
   const locale =
     useSelect('locale', localeProp, localeDefault) || localeDefault;
   const dateTimeView = useSelect(
@@ -109,6 +110,26 @@ const Variants = () => {
 
   const icon = withIcon ? IconCalendar : undefined;
 
+  const getDisableDates = (): Array<Date | [Date, Date]> => {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const day = date.getDate();
+    return [
+      // интервал времени текущей даты с 12:34:20 - 16:10:41
+      [
+        new Date(year, month, day, 12, 34, 20),
+        new Date(year, month, day, 16, 10, 41),
+      ],
+      // следующий день
+      new Date(year, month, day + 1),
+      // отключаем с 2го по 12ое включительно
+      [new Date(year, month, 2), new Date(year, month, 13)],
+    ];
+  };
+
+  const disableDates = withDisableDates ? getDisableDates() : undefined;
+
   useEffect(() => {
     setValue(null);
   }, [type]);
@@ -127,6 +148,7 @@ const Variants = () => {
         status={status}
         view={view}
         disabled={disabled}
+        disableDates={disableDates}
         size={size}
         onChange={setValue}
         leftSide={icon}

--- a/src/components/DatePicker/__tests__/DatePicker_type_date.test.tsx
+++ b/src/components/DatePicker/__tests__/DatePicker_type_date.test.tsx
@@ -1,10 +1,15 @@
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import * as React from 'react';
 
-import { DatePicker, DatePickerProps } from '../DatePicker';
+import {
+  DatePicker,
+  DatePickerPropDateTimeView,
+  DatePickerProps,
+} from '../DatePicker';
 import {
   animateDelay,
   getDateTimeItem,
+  getDateTimeItemByText,
   getDateTimeItemSelected,
   getInput,
   inputFocus,
@@ -58,6 +63,61 @@ describe('Компонент DatePicker_type_date', () => {
       animateDelay();
 
       expect(getDateTimeItemSelected()).toHaveTextContent('15');
+    });
+  });
+
+  describe('проверка disableDates', () => {
+    it('корректно отключает даты при dateTimeView="classic"', () => {
+      jest.useFakeTimers();
+
+      act(() => {
+        renderComponent({
+          currentVisibleDate: new Date(1970, 0),
+          disableDates: [[new Date(1970, 0, 20), new Date(1970, 0, 23)]],
+          dateTimeView: 'classic',
+        });
+      });
+
+      inputFocus();
+      animateDelay();
+
+      expect(getDateTimeItemByText('20')).toBeDisabled();
+      expect(getDateTimeItemByText('21')).toBeDisabled();
+      expect(getDateTimeItemByText('22')).toBeDisabled();
+    });
+
+    describe('корректно отключает даты с 2 сторон', () => {
+      jest.useFakeTimers();
+
+      const viewTests: DatePickerPropDateTimeView[] = ['book', 'slider'];
+
+      test.each(viewTests)('dateTimeView=%s', (dateTimeView) => {
+        act(() => {
+          renderComponent({
+            currentVisibleDate: new Date(1970, 0),
+            disableDates: [
+              [new Date(1970, 0, 20), new Date(1970, 0, 23)],
+              [new Date(1970, 1, 10), new Date(1970, 1, 13)],
+            ],
+            dateTimeView,
+          });
+        });
+
+        inputFocus();
+        animateDelay();
+
+        // Отключенные даты в левой стороне календаря (январь)
+        expect(getDateTimeItem(22)).toBeDisabled();
+        expect(getDateTimeItem(23)).toBeDisabled();
+        expect(getDateTimeItem(24)).toBeDisabled();
+
+        // Отключенные даты в правой стороне календаря (февраль)
+        expect(getDateTimeItem(57)).toBeDisabled();
+        expect(getDateTimeItem(58)).toBeDisabled();
+        expect(getDateTimeItem(59)).toBeDisabled();
+
+        cleanup();
+      });
     });
   });
 });

--- a/src/components/DatePicker/__tests__/DatePicker_type_dateRange.test.tsx
+++ b/src/components/DatePicker/__tests__/DatePicker_type_dateRange.test.tsx
@@ -1,10 +1,15 @@
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import * as React from 'react';
 
-import { DatePicker, DatePickerProps } from '../DatePicker';
+import {
+  DatePicker,
+  DatePickerPropDateTimeView,
+  DatePickerProps,
+} from '../DatePicker';
 import {
   animateDelay,
   getDateTimeItem,
+  getDateTimeItemByText,
   getDateTimeItemSelected,
   getInput,
   inputFocus,
@@ -63,6 +68,61 @@ describe('Компонент DatePicker_type_dateRange', () => {
 
       expect(getDateTimeItemSelected(0)).toHaveTextContent('15');
       expect(getDateTimeItemSelected(1)).toHaveTextContent('17');
+    });
+  });
+
+  describe('проверка disableDates', () => {
+    it('корректно отключает даты при dateTimeView="classic"', () => {
+      jest.useFakeTimers();
+
+      act(() => {
+        renderComponent({
+          currentVisibleDate: new Date(1970, 0),
+          disableDates: [[new Date(1970, 0, 20), new Date(1970, 0, 23)]],
+          dateTimeView: 'classic',
+        });
+      });
+
+      inputFocus();
+      animateDelay();
+
+      expect(getDateTimeItemByText('20')).toBeDisabled();
+      expect(getDateTimeItemByText('21')).toBeDisabled();
+      expect(getDateTimeItemByText('22')).toBeDisabled();
+    });
+
+    describe('корректно отключает даты с 2 сторон', () => {
+      jest.useFakeTimers();
+
+      const viewTests: DatePickerPropDateTimeView[] = ['book', 'slider'];
+
+      test.each(viewTests)('dateTimeView=%s', (dateTimeView) => {
+        act(() => {
+          renderComponent({
+            currentVisibleDate: new Date(1970, 0),
+            disableDates: [
+              [new Date(1970, 0, 20), new Date(1970, 0, 23)],
+              [new Date(1970, 1, 10), new Date(1970, 1, 13)],
+            ],
+            dateTimeView,
+          });
+        });
+
+        inputFocus();
+        animateDelay();
+
+        // Отключенные даты в левой стороне календаря (январь)
+        expect(getDateTimeItem(22)).toBeDisabled();
+        expect(getDateTimeItem(23)).toBeDisabled();
+        expect(getDateTimeItem(24)).toBeDisabled();
+
+        // Отключенные даты в правой стороне календаря (февраль)
+        expect(getDateTimeItem(57)).toBeDisabled();
+        expect(getDateTimeItem(58)).toBeDisabled();
+        expect(getDateTimeItem(59)).toBeDisabled();
+
+        cleanup();
+      });
     });
   });
 });

--- a/src/components/DatePicker/__tests__/DatePicker_type_dateTime.test.tsx
+++ b/src/components/DatePicker/__tests__/DatePicker_type_dateTime.test.tsx
@@ -6,6 +6,8 @@ import {
   animateDelay,
   getDateTimeDaySelected,
   getDateTimeItem,
+  getDateTimeItemByText,
+  getDateTimeTimeItem,
   getDateTimeTimeSelected,
   getInput,
   inputFocus,
@@ -64,6 +66,49 @@ describe('Компонент DatePicker_type_dateTime', () => {
       expect(getDateTimeTimeSelected(0)).toHaveTextContent('10');
       expect(getDateTimeTimeSelected(1)).toHaveTextContent('11');
       expect(getDateTimeTimeSelected(2)).toHaveTextContent('12');
+    });
+  });
+
+  describe('проверка disableDates', () => {
+    it('корректно отключает даты', () => {
+      jest.useFakeTimers();
+
+      act(() => {
+        renderComponent({
+          currentVisibleDate: new Date(1970, 0),
+          disableDates: [[new Date(1970, 0, 20), new Date(1970, 0, 23)]],
+          dateTimeView: 'classic',
+        });
+      });
+
+      inputFocus();
+      animateDelay();
+
+      expect(getDateTimeItemByText('20')).toBeDisabled();
+      expect(getDateTimeItemByText('21')).toBeDisabled();
+      expect(getDateTimeItemByText('22')).toBeDisabled();
+    });
+
+    it('корректно отключает часы', () => {
+      jest.useFakeTimers();
+
+      act(() => {
+        renderComponent({
+          value: new Date(1970, 0, 1),
+          currentVisibleDate: new Date(1970, 0),
+          disableDates: [
+            [new Date(1970, 0, 1, 2, 0, 0), new Date(1970, 0, 1, 6, 0, 0)],
+          ],
+          dateTimeView: 'classic',
+        });
+      });
+
+      inputFocus();
+      animateDelay();
+
+      expect(getDateTimeTimeItem(3)).toBeDisabled(); // время 03:00
+      expect(getDateTimeTimeItem(4)).toBeDisabled(); // время 04:00
+      expect(getDateTimeTimeItem(5)).toBeDisabled(); // время 05:00
     });
   });
 });

--- a/src/components/DatePicker/__tests__/helpers.ts
+++ b/src/components/DatePicker/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, within } from '@testing-library/react';
 
 import { animateTimeout } from '../../../mixs/MixPopoverAnimate/MixPopoverAnimate';
 
@@ -22,7 +22,12 @@ export const animateDelay = () =>
   });
 export const getDateTimeItems = () =>
   getDropdown().querySelectorAll(`.DateTimeItem`);
+export const getDateTimeTimeItems = () =>
+  getDropdown().querySelectorAll(`.DateTimeTypeDateTime-Time .DateTimeItem`);
 export const getDateTimeItem = (item = 0) => getDateTimeItems()[item];
+export const getDateTimeTimeItem = (item = 0) => getDateTimeTimeItems()[item];
+export const getDateTimeItemByText = (dateText: string) =>
+  within(getDropdown()).getByText(dateText);
 export const getDateTimeItemsSelected = () =>
   getDropdown().querySelectorAll(`.DateTimeItem_selected`);
 export const getDateTimeItemSelected = (item = 0) =>

--- a/src/components/DateTime/DateTimeTypeDate/DateTimeTypeDate.tsx
+++ b/src/components/DateTime/DateTimeTypeDate/DateTimeTypeDate.tsx
@@ -134,6 +134,7 @@ export const DateTimeTypeDate: DateTimeTypeComponent<'date'> = forwardRef(
 
     const pageTwoDaysOfMonth = getDaysOfMonth({
       date: pageTwoCurrentVisibleDate,
+      disableDates,
       handleDayClick: handleSelectDate,
       value,
       events,


### PR DESCRIPTION
## Описание изменений
closes #3927

В DatePicker поправил 2 бага:
1. в правой стороне календаря не отображались `disableDates` при `dateTimeView='book' или 'slider'`
2. в `type='date'` в дропдаун не были прокинуты `disableDates`, из за этого disableDates также не отображались

Также для стенда с `DatePicker` добавил опцию просмотра `withDisableDates`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
