### PR TITLE
fix(Attachment): не передавать withAction, как пропс в html тег

### DIFF
--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -56,6 +56,7 @@ const Attachment = forwardRefWithAs<AttachmentProps>((props, ref) => {
     buttonTitle,
     buttonIcon,
     onButtonClick,
+    withAction,
     ...otherProps
   } = props;
   const Tag = as as string;


### PR DESCRIPTION
## Описание изменений

deprecated свойство withAction передается пропсом в html элемент, что вызывает ошибку

`Warning: React does not recognize the `withAction` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `withaction` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
        at div
        at className (/home/gitlab-runner/builds/CM_VycHn/0/asklegal/asklegal-redisign-f/node_modules/@consta/src/components/Attachment/Attachment.tsx:43:5)`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
