### PR TITLE
fix(Combobox): fix combobox clear button visibility with multiple=true

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -266,6 +266,10 @@ const ComboboxRender = <
     return renderControlValue();
   };
 
+  const isClearButtonVisible = isMultipleParams(props)
+    ? isNotNil(props.value) && props.value.length > 0
+    : isNotNil(props.value);
+
   return (
     <>
       <SelectContainer
@@ -301,7 +305,7 @@ const ComboboxRender = <
             </div>
           </div>
           <span className={cnSelect('Indicators')}>
-            {isNotNil(value) && (
+            {isClearButtonVisible && (
               <button
                 type="button"
                 onClick={clearValue}


### PR DESCRIPTION
## Описание изменений
closes #4060.
Поправил `multiple` в `Combobox`, теперь кнопка очистки корректно не отображается если ничего в `Combobox` не выбрано.
Добавил тестов для `Combobox`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
