### PR TITLE
test(Slider/Sidebar): добавить тесты для Slider, Sidebar

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,11 @@ module.exports = {
     // Транспайлим библиотеки на es-модулях в commonjs-модули
     `<rootDir>/node_modules/(?!(@consta)/).+\\.(js|jsx|ts|tsx)`,
   ],
-  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/*.stories.tsx'],
+  collectCoverageFrom: [
+    '**/*.{ts,tsx}',
+    '!**/*.stories.tsx',
+    '!**/__stand__/**',
+  ],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./jest.setup.ts'],
 };

--- a/src/components/Modal/__tests__/Modal.test.tsx
+++ b/src/components/Modal/__tests__/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 
 import { Modal } from '../Modal';
@@ -70,21 +70,36 @@ describe('Компонент Modal', () => {
     });
   });
 
-  // Исправить
-  // describe('проверка onOpen и onClose', () => {
-  //   const onOpen = jest.fn();
-  //   const onClose = jest.fn();
-  //   const { rerender } = render(getComponent({ onClose, onOpen }));
+  describe("проверка callback'ов", () => {
+    it('onOpen должен вызваться после рендера', () => {
+      const onOpen = jest.fn();
+      const onClose = jest.fn();
+      render(getComponent({ onClose, onOpen }));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(0);
+    });
 
-  //   it('onOpen должен вызваться после рендера', () => {
-  //     expect(onOpen).toHaveBeenCalledTimes(1);
-  //     expect(onClose).toHaveBeenCalledTimes(0);
-  //   });
+    it('onClose должен вызваться в момент закрытия', () => {
+      const onOpen = jest.fn();
+      const onClose = jest.fn();
+      const { rerender } = render(getComponent({ onClose, onOpen }));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      rerender(getComponent({ onClose, onOpen, isOpen: false }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
 
-  //   it('onClose должен вызваться после закрытия', () => {
-  //     rerender(getComponent({ onClose, onOpen, isOpen: false }));
-  //     expect(onOpen).toHaveBeenCalledTimes(1);
-  //     expect(onClose).toHaveBeenCalledTimes(1);
-  //   });
-  // });
+    it('afterClose должен вызваться после закрытия', () => {
+      jest.useFakeTimers();
+      const afterClose = jest.fn();
+      const { rerender } = render(getComponent({ isOpen: true, afterClose }));
+
+      rerender(getComponent({ isOpen: false, afterClose }));
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(afterClose).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -33,7 +33,7 @@ export const sidebarPropSize = [
 export type SidebarPropSize = typeof sidebarPropSize[number];
 const sidebarPropSizeDefault: SidebarPropSize = sidebarPropSize[1];
 
-type SidebarProps = PropsWithHTMLAttributes<
+export type SidebarProps = PropsWithHTMLAttributes<
   {
     isOpen?: boolean;
     onClose?: () => void;

--- a/src/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { cnSidebar, Sidebar, SidebarProps, sidebarPropSize } from '../Sidebar';
+
+const testId = 'Sidebar';
+
+const renderComponent = (props: SidebarProps) => {
+  return render(<Sidebar data-testid={testId} {...props} />);
+};
+
+const getRender = () => {
+  return screen.getByTestId(testId);
+};
+
+const getSidebarContent = () => {
+  return getRender().querySelector(`.${cnSidebar('Content')}`);
+};
+
+const getSidebarActions = () => {
+  return getRender().querySelector(`.${cnSidebar('Actions')}`);
+};
+
+const getOverlay = () => {
+  return document.querySelector(`.${cnSidebar('Overlay')}`)!;
+};
+
+describe('Компонент Sidebar', () => {
+  it('рендерится без ошибок', () => {
+    expect(renderComponent).not.toThrow();
+  });
+
+  it('SidebarContent отображается корректно', () => {
+    const textContent = 'content';
+    renderComponent({
+      isOpen: true,
+      children: <Sidebar.Content>{textContent}</Sidebar.Content>,
+    });
+    const content = getSidebarContent();
+    expect(content).toHaveTextContent(textContent);
+  });
+
+  it('SidebarActions отображается корректно', () => {
+    const textContent = 'content';
+    renderComponent({
+      isOpen: true,
+      children: <Sidebar.Actions>{textContent}</Sidebar.Actions>,
+    });
+    const actions = getSidebarActions();
+    expect(actions).toHaveTextContent(textContent);
+  });
+
+  describe('проверка overlay', () => {
+    it('overlay отображается при hasOverlay=true', () => {
+      renderComponent({
+        isOpen: true,
+        hasOverlay: true,
+        children: <div>text</div>,
+      });
+
+      const overlay = getOverlay();
+
+      expect(overlay).toBeInTheDocument();
+    });
+
+    it('overlay не отображается при hasOverlay=false', () => {
+      renderComponent({
+        isOpen: true,
+        hasOverlay: false,
+        children: <div>text</div>,
+      });
+
+      const overlay = getOverlay();
+
+      expect(overlay).not.toBeInTheDocument();
+    });
+  });
+
+  describe("проверка callback'ов", () => {
+    it('onOpen вызывается при открытии', () => {
+      const handleOpen = jest.fn();
+      const { rerender } = renderComponent({
+        isOpen: false,
+        onOpen: handleOpen,
+      });
+
+      rerender(
+        <Sidebar isOpen onOpen={handleOpen}>
+          text
+        </Sidebar>,
+      );
+
+      expect(handleOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it('onClose вызывается при закрытии', () => {
+      const handleClose = jest.fn();
+      const { rerender } = renderComponent({
+        isOpen: true,
+        onClose: handleClose,
+      });
+
+      rerender(
+        <Sidebar isOpen={false} onClose={handleClose}>
+          text
+        </Sidebar>,
+      );
+
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('onEsc вызывается при нажатии Escape', () => {
+      const handleEsc = jest.fn();
+      renderComponent({ isOpen: true, onEsc: handleEsc });
+
+      fireEvent.keyUp(document, { key: 'Escape' });
+
+      expect(handleEsc).toHaveBeenCalledTimes(1);
+    });
+
+    it('onClickOutside вызывается при клике вне сайдбара', () => {
+      const handleClickOutside = jest.fn();
+      renderComponent({ isOpen: true, onClickOutside: handleClickOutside });
+
+      fireEvent.mouseDown(getOverlay());
+
+      expect(handleClickOutside).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('проверка props', () => {
+    it('рендерится в указанный container', () => {
+      const portal = document.createElement('div');
+      portal.setAttribute('id', 'portal');
+      document.body.appendChild(portal);
+
+      renderComponent({ isOpen: true, container: portal });
+
+      expect(portal).toContainElement(getRender());
+      document.body.removeChild(portal);
+    });
+
+    test.each(sidebarPropSize)('применяется класс для размера %p', (size) => {
+      renderComponent({ isOpen: true, size });
+      const sidebarWindow = getRender();
+      expect(sidebarWindow).toHaveClass(cnSidebar('Window', { size }));
+    });
+  });
+});

--- a/src/components/Slider/__tests__/Slider.test.tsx
+++ b/src/components/Slider/__tests__/Slider.test.tsx
@@ -1,0 +1,199 @@
+import { IconQuestion } from '@consta/icons/IconQuestion';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SliderProps, sliderPropSize, SliderPropView } from '../helper';
+import { Slider } from '../Slider';
+
+const testId = 'Slider';
+
+const renderComponent = <RANGE extends boolean = false>(
+  props: SliderProps<RANGE>,
+) => {
+  return render(<Slider data-testid={testId} {...props} />);
+};
+
+const getRender = () => {
+  return screen.getByTestId(testId);
+};
+
+const getPoints = () => {
+  return getRender().querySelectorAll('[role="slider"]');
+};
+
+const getLine = () => {
+  return getRender().querySelector('.SliderLine');
+};
+
+describe('Компонент Slider', () => {
+  it('рендерится без ошибок', () => {
+    expect(() => renderComponent({ value: 0 })).not.toThrow();
+  });
+
+  it('рендерится с range', () => {
+    renderComponent({ value: [0, 100], range: true });
+    expect(getPoints().length).toBe(2);
+  });
+
+  describe('проверка props', () => {
+    describe('проверка size', () => {
+      test.each(sliderPropSize)(`применяется класс для size=%p`, (size) => {
+        renderComponent({ value: 0, size });
+        expect(getRender()).toHaveClass(`Slider_size_${size}`);
+      });
+    });
+
+    describe('проверка view', () => {
+      test.each(['default', 'division'] as SliderPropView[])(
+        'применяется класс для view=%p',
+        (view) => {
+          renderComponent({ value: 0, view });
+          expect(getLine()).toHaveClass(`SliderLine_view_${view}`);
+        },
+      );
+    });
+
+    it('disabled отключает компонент', () => {
+      const handleChange = jest.fn();
+      renderComponent({ value: 0, disabled: true, onChange: handleChange });
+      const point = getPoints()[0] as HTMLButtonElement;
+      point.focus();
+
+      fireEvent.keyDown(point, { key: 'ArrowRight' });
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('отображает label и caption', () => {
+      const label = 'Test Label';
+      const caption = 'Test Caption';
+      renderComponent({ value: 0, label, caption });
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(caption)).toBeInTheDocument();
+    });
+
+    it('отображает leftSide и rightSide как input', () => {
+      renderComponent({
+        value: [20, 80],
+        range: true,
+        leftSide: 'input',
+        rightSide: 'input',
+      });
+      const inputs = screen.getAllByRole('spinbutton');
+      expect(inputs.length).toBe(2);
+      expect(inputs[0]).toHaveValue(20);
+      expect(inputs[1]).toHaveValue(80);
+    });
+
+    it('отображает leftSide и rightSide как иконки', () => {
+      renderComponent({
+        value: [20, 80],
+        range: true,
+        leftSide: () => <IconQuestion data-testid="iconLeft" />,
+        rightSide: () => <IconQuestion data-testid="iconRight" />,
+      });
+      expect(screen.getByTestId('iconLeft')).toBeInTheDocument();
+      expect(screen.getByTestId('iconRight')).toBeInTheDocument();
+    });
+
+    it('изменяет значение с учетом step', () => {
+      const handleChange = jest.fn();
+      const step = 10;
+      const initialValue = 50;
+      renderComponent({
+        value: initialValue,
+        step,
+        onChange: handleChange,
+      });
+      const point = getPoints()[0] as HTMLButtonElement;
+      point.focus();
+
+      fireEvent.keyDown(point, { key: 'ArrowRight' });
+
+      expect(handleChange).toHaveBeenCalledWith(
+        initialValue + step,
+        expect.any(Object),
+      );
+    });
+
+    describe('проверка min/max', () => {
+      it('значение не может быть меньше min', () => {
+        const handleChange = jest.fn();
+        const min = 20;
+        renderComponent({
+          value: min,
+          min,
+          onChange: handleChange,
+          leftSide: 'input',
+        });
+        const point = getPoints()[0] as HTMLButtonElement;
+        point.focus();
+
+        fireEvent.keyDown(point, { key: 'ArrowLeft' });
+        expect(handleChange).toHaveBeenCalledWith(min, expect.any(Object));
+      });
+
+      it('значение не может быть больше max', () => {
+        const handleChange = jest.fn();
+        const max = 80;
+        renderComponent({
+          value: max,
+          max,
+          onChange: handleChange,
+        });
+        const point = getPoints()[0] as HTMLButtonElement;
+        point.focus();
+
+        fireEvent.keyDown(point, { key: 'ArrowRight' });
+        expect(handleChange).toHaveBeenCalledWith(max, expect.any(Object));
+      });
+
+      it('поля ввода имеют правильные min/max для range', () => {
+        const min = 10;
+        const max = 90;
+        const value: [number, number] = [30, 70];
+        renderComponent({
+          value,
+          range: true,
+          min,
+          max,
+          leftSide: 'input',
+          rightSide: 'input',
+        });
+        const inputs = screen.getAllByRole('spinbutton');
+        expect(inputs[0]).toHaveAttribute('min', min.toString());
+        expect(inputs[0]).toHaveAttribute('max', value[1].toString());
+        expect(inputs[1]).toHaveAttribute('min', value[0].toString());
+        expect(inputs[1]).toHaveAttribute('max', max.toString());
+      });
+    });
+  });
+
+  describe("проверка callback'ов", () => {
+    it('onChange вызывается после изменения значения с SliderPoint', () => {
+      const handleChange = jest.fn();
+      renderComponent({ value: 50, onChange: handleChange });
+      const point = getPoints()[0] as HTMLButtonElement;
+      point.focus();
+      fireEvent.keyDown(point, { key: 'ArrowRight' });
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('onChange вызывается после изменения значения с SliderInput', () => {
+      const handleChange = jest.fn();
+      const initialValue = 50;
+      renderComponent({
+        value: initialValue,
+        onChange: handleChange,
+        leftSide: 'input',
+      });
+
+      const input = screen.getByRole('spinbutton');
+      const newValue = 60;
+
+      fireEvent.change(input, { target: { value: newValue.toString() } });
+      fireEvent.blur(input);
+
+      expect(handleChange).toHaveBeenCalledWith(newValue, expect.any(Object));
+    });
+  });
+});

--- a/src/components/Slider/__tests__/SliderInput.test.tsx
+++ b/src/components/Slider/__tests__/SliderInput.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SliderInput } from '../SliderInput/SliderInput';
+
+const testId = 'SliderInput';
+
+const renderComponent = (props: React.ComponentProps<typeof SliderInput>) => {
+  return render(<SliderInput data-testid={testId} {...props} />);
+};
+
+const getSliderInput = () => screen.getByRole('spinbutton');
+
+describe('Компонент SliderInput', () => {
+  it('рендерится без ошибок', () => {
+    expect(() => renderComponent({ value: 50 })).not.toThrow();
+  });
+
+  it('отображает начальное значение', () => {
+    const value = 50;
+    renderComponent({ value });
+    const input = getSliderInput();
+
+    expect(input).toHaveValue(value);
+  });
+
+  it('вызывает onChange при вводе валидного значения', () => {
+    const handleChange = jest.fn();
+
+    renderComponent({ value: 50, onChange: handleChange, max: 100 });
+    const input = getSliderInput();
+    fireEvent.change(input, { target: { value: '75' } });
+
+    expect(handleChange).toHaveBeenCalledWith({
+      value: 75,
+      e: expect.any(Object),
+    });
+  });
+
+  it('не вызывает onChange при вводе невалидного значения', () => {
+    const handleChange = jest.fn();
+
+    renderComponent({ value: 50, onChange: handleChange, max: 100 });
+    const input = getSliderInput();
+    fireEvent.change(input, { target: { value: '150' } });
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('при потере фокуса (blur) корректирует значение до max', () => {
+    const handleChange = jest.fn();
+    const max = 100;
+
+    renderComponent({ value: 50, onChange: handleChange, max });
+    const input = getSliderInput();
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.blur(input);
+
+    expect(handleChange).toHaveBeenCalledWith({ value: max });
+    expect(input).toHaveValue(max);
+  });
+
+  it('при потере фокуса (blur) корректирует значение до min', () => {
+    const handleChange = jest.fn();
+    const min = 10;
+
+    renderComponent({ value: 50, onChange: handleChange, min });
+    const input = getSliderInput();
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.blur(input);
+
+    expect(handleChange).toHaveBeenCalledWith({ value: min });
+    expect(input).toHaveValue(min);
+  });
+
+  it('обновляет значение при изменении props.value', () => {
+    const { rerender } = renderComponent({ value: 50 });
+
+    const input = getSliderInput();
+    expect(input).toHaveValue(50);
+
+    const newValue = 75;
+    rerender(<SliderInput data-testid={testId} value={newValue} />);
+    expect(input).toHaveValue(newValue);
+  });
+
+  it('отключен, если disabled=true', () => {
+    renderComponent({ value: 50, disabled: true });
+
+    const input = getSliderInput();
+    expect(input).toBeDisabled();
+  });
+});

--- a/src/components/Slider/__tests__/SliderLine.test.tsx
+++ b/src/components/Slider/__tests__/SliderLine.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SliderLineProps } from '../helper';
+import { SliderLine } from '../SliderLine/SliderLine';
+
+const testId = 'SliderLine';
+
+const defaultLines: SliderLineProps['lines'] = [
+  { width: 50, active: true },
+  { width: 50, active: false },
+];
+
+const renderComponent = (props: Partial<SliderLineProps> = {}) => {
+  return render(
+    <SliderLine data-testid={testId} lines={defaultLines} {...props} />,
+  );
+};
+
+const getRender = () => {
+  return screen.getByTestId(testId);
+};
+
+const getLines = () => {
+  return getRender().querySelectorAll('.SliderLine-Line');
+};
+
+const getActiveLine = () => {
+  return getRender().querySelector('.SliderLine-Line_active');
+};
+
+const getInactiveLine = () => {
+  return getRender().querySelector(
+    '.SliderLine-Line:not(.SliderLine-Line_active)',
+  );
+};
+
+describe('Компонент SliderLine', () => {
+  it('рендерится без ошибок', () => {
+    expect(() => renderComponent()).not.toThrow();
+  });
+
+  it('рендерит правильное количество сегментов линии', () => {
+    renderComponent();
+    expect(getLines().length).toBe(defaultLines.length);
+  });
+
+  it('устанавливает правильную ширину для сегментов', () => {
+    renderComponent();
+    const lines = getLines();
+    lines.forEach((line, index) => {
+      expect(line).toHaveStyle(
+        `--slider-line-size: ${defaultLines[index].width}%`,
+      );
+    });
+  });
+
+  describe('проверка props', () => {
+    it('применяет класс для view="division"', () => {
+      renderComponent({ view: 'division' });
+      expect(getRender()).toHaveClass('SliderLine_view_division');
+    });
+
+    it('применяет класс active для активного сегмента', () => {
+      renderComponent();
+      expect(getActiveLine()).toBeInTheDocument();
+      expect(getInactiveLine()).toBeInTheDocument();
+    });
+
+    it('применяет класс hovered для активного сегмента', () => {
+      renderComponent({ hovered: true });
+      expect(getActiveLine()).toHaveClass('SliderLine-Line_hovered');
+      expect(getInactiveLine()).not.toHaveClass('SliderLine-Line_hovered');
+    });
+
+    it('применяет класс disabled для всех сегментов', () => {
+      renderComponent({ disabled: true });
+      getLines().forEach((line) => {
+        expect(line).toHaveClass('SliderLine-Line_disabled');
+      });
+    });
+  });
+
+  describe('проверка onHover', () => {
+    it('вызывает onHover при наведении на активный сегмент', () => {
+      const onHover = jest.fn();
+      renderComponent({ onHover });
+      const activeLine = getActiveLine();
+
+      fireEvent.mouseEnter(activeLine!);
+      expect(onHover).toHaveBeenCalledWith(true);
+
+      fireEvent.mouseLeave(activeLine!);
+      expect(onHover).toHaveBeenCalledWith(false);
+    });
+
+    it('не вызывает onHover при наведении на неактивный сегмент', () => {
+      const onHover = jest.fn();
+      renderComponent({ onHover });
+      const inactiveLine = getInactiveLine();
+
+      fireEvent.mouseEnter(inactiveLine!);
+      expect(onHover).not.toHaveBeenCalled();
+    });
+
+    it('не вызывает onHover, если disabled=true', () => {
+      const onHover = jest.fn();
+      renderComponent({ onHover, disabled: true });
+      const activeLine = getActiveLine();
+
+      fireEvent.mouseEnter(activeLine!);
+      expect(onHover).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/Slider/__tests__/SliderPoint.test.tsx
+++ b/src/components/Slider/__tests__/SliderPoint.test.tsx
@@ -1,0 +1,192 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SliderPointProps } from '../helper';
+import { SliderPoint } from '../SliderPoint/SliderPoint';
+
+const testId = 'SliderPoint';
+
+const buttonLabel = 0;
+
+const defaultProps: SliderPointProps = {
+  value: 50,
+  position: 50,
+  buttonLabel,
+};
+
+const renderComponent = (props: SliderPointProps) => {
+  return render(<SliderPoint data-testid={testId} {...props} />);
+};
+
+const getRender = () => {
+  return screen.getByTestId(testId);
+};
+
+const getTooltip = () => {
+  return document.querySelector('.Tooltip');
+};
+
+describe('Компонент SliderPoint', () => {
+  it('рендерится без ошибок', () => {
+    expect(() => renderComponent(defaultProps)).not.toThrow();
+  });
+
+  describe('проверка props', () => {
+    it('применяет disabled', () => {
+      const onFocus = jest.fn();
+      renderComponent({ ...defaultProps, disabled: true, onFocus });
+      const point = getRender();
+
+      fireEvent.focus(point);
+
+      expect(point).toHaveClass('SliderPoint_disabled');
+      expect(onFocus).not.toHaveBeenCalled();
+    });
+
+    it('применяет hovered', () => {
+      renderComponent({ ...defaultProps, hovered: true });
+      expect(getRender()).toHaveClass('SliderPoint_hovered');
+    });
+
+    it('применяет active', () => {
+      renderComponent({ ...defaultProps, active: true });
+      expect(getRender()).toHaveClass('SliderPoint_active');
+    });
+
+    it('устанавливает position', () => {
+      const position = 75;
+      renderComponent({ position });
+      expect(getRender()).toHaveStyle(`--slider-button-left: ${position}%`);
+    });
+
+    it('устанавливает aria-label', () => {
+      renderComponent(defaultProps);
+      expect(getRender()).toHaveAttribute(
+        'aria-label',
+        `${buttonLabel}-button`,
+      );
+    });
+  });
+
+  describe("проверка callback'ов", () => {
+    it('вызывает onHover при наведении', () => {
+      const onHover = jest.fn();
+      renderComponent({ ...defaultProps, onHover });
+      const point = getRender();
+
+      fireEvent.mouseOver(point);
+      expect(onHover).toHaveBeenCalledWith(true);
+
+      fireEvent.mouseOut(point);
+      expect(onHover).toHaveBeenCalledWith(false);
+    });
+
+    it('вызывает handlePress при mousedown', () => {
+      const handlePress = jest.fn();
+      renderComponent({ ...defaultProps, handlePress });
+
+      fireEvent.mouseDown(getRender());
+      expect(handlePress).toHaveBeenCalledWith(buttonLabel);
+    });
+
+    it('вызывает onKeyPress при keydown', () => {
+      const onKeyPress = jest.fn();
+      renderComponent({ ...defaultProps, onKeyPress });
+
+      fireEvent.keyDown(getRender(), { key: 'ArrowRight' });
+      expect(onKeyPress).toHaveBeenCalled();
+    });
+
+    it('вызывает onFocus при focus и blur', () => {
+      const onFocus = jest.fn();
+      renderComponent({ ...defaultProps, onFocus });
+      const point = getRender();
+
+      fireEvent.focus(point);
+      expect(onFocus).toHaveBeenCalledWith(expect.any(Object), buttonLabel);
+
+      fireEvent.blur(point);
+      expect(onFocus).toHaveBeenCalledWith(expect.any(Object), null);
+    });
+  });
+
+  describe('проверка Tooltip', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    const popoverPosition: SliderPointProps['popoverPosition'] = {
+      x: 50,
+      y: 50,
+    };
+
+    const showHoverTooltip = () => {
+      fireEvent.mouseOver(getRender());
+      act(() => {
+        jest.runAllTimers();
+      });
+    };
+
+    it('появляется при наведении', () => {
+      renderComponent({ ...defaultProps, withTooltip: true, popoverPosition });
+
+      showHoverTooltip();
+
+      expect(getTooltip()).toBeInTheDocument();
+    });
+
+    it('появляется при фокусе', () => {
+      renderComponent({ ...defaultProps, withTooltip: true, popoverPosition });
+      fireEvent.focus(getRender());
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(getTooltip()).toBeInTheDocument();
+    });
+
+    it('исчезает при потере фокуса', () => {
+      renderComponent({ ...defaultProps, withTooltip: true, popoverPosition });
+      const point = getRender();
+
+      fireEvent.focus(getRender());
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(getTooltip()).toBeInTheDocument();
+
+      fireEvent.blur(point);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(getTooltip()).not.toBeInTheDocument();
+    });
+
+    it('использует tooltipFormatter', () => {
+      const formatter = (value?: number | string) => `${value}%`;
+
+      renderComponent({
+        ...defaultProps,
+        withTooltip: true,
+        tooltipFormatter: formatter,
+        popoverPosition,
+      });
+
+      showHoverTooltip();
+
+      expect(getTooltip()?.textContent).toBe(formatter(defaultProps.value));
+    });
+
+    it('не показывается если withTooltip=false', () => {
+      renderComponent({ ...defaultProps, withTooltip: false, popoverPosition });
+      showHoverTooltip();
+
+      expect(getTooltip()).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Добавил отсутствующие тесты для компонент `Slider` и `Sidebar`.
Исправил закоментированный тест в компоненте `Modal`.

Также предлагаю добавить папку со стендами `__stand__` в игнор в collectCoverageFrom, так будет собираться более реальный процент покрытия.
Пример до:
<img width="150" height="493" alt="image" src="https://github.com/user-attachments/assets/bed06a13-ff96-4f13-b36a-0b445f1696a0" />

После:
<img width="150" height="493" alt="image" src="https://github.com/user-attachments/assets/484dd2cd-3fe8-4d61-a6c5-a3dc5a12e8c4" />


## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
