### PR TITLE
fix(ci): fix duplicate typecheck in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Установка зависимостей
         run: yarn add "install-peers-cli@https://github.com/evless/install-peers-cli#fix-yarn-policies" && yarn --frozen-lockfile
       - name: Проверка TS
-        run: yarn tsc --noEmit
+        run: yarn run tsc-dry-run
       - name: Unit тесты
-        run: yarn tsc --noEmit
+        run: yarn run unit
+      - name: Проверка eslint & stylelint
+        run: yarn run lint
       - name: Проверка орфографии
         run: yarn cspell --no-progress


### PR DESCRIPTION
В последних пулреквестах заметил что компиляция тайпскрипта прогоняется в 2 джобах, вместо запуска тестов, выглядит как опечатка? В джобе unit тесты заменил ts на запуск тестов.
<img width="1238" height="648" alt="image" src="https://github.com/user-attachments/assets/0bac4a7a-e37c-47fa-ac87-3f9673f25cce" />


Также добавил джобу для запуска линтеров, сейчас они прогоняются только в прекомитах, что не особо надежно, т.к. их можно легко скипнуть, closes #3386

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
