### PR TITLE
fix(ContextMenu): remove unused ref

### DIFF
--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -38,7 +38,6 @@ const ContextMenuRender = (
       <ContextMenuLevels
         {...rest}
         setComponentSize={setComponentSize}
-        ref={ref}
         enableAnimationBack={setAnimationBack.on}
         disableAnimationBack={disableAnimationBack}
       />

--- a/src/components/ContextMenu/ContextMenuLevels/ContextMenuLevels.tsx
+++ b/src/components/ContextMenu/ContextMenuLevels/ContextMenuLevels.tsx
@@ -13,7 +13,6 @@ import { getLevels, withDefaultGetters } from '../helpers';
 import {
   AddLevel,
   ContextMenuItemDefault,
-  ContextMenuLevelsComponent,
   ContextMenuLevelsProps,
   contextMenuPropDefaultSubMenuDirection,
   contextMenuPropSubMenuDirections,
@@ -21,10 +20,7 @@ import {
 } from '../types';
 import { useSize } from './useSize';
 
-const ContextMenuLevelsRender = (
-  propsComponent: ContextMenuLevelsProps,
-  ref: React.Ref<HTMLDivElement>,
-) => {
+export const ContextMenuLevels = (propsComponent: ContextMenuLevelsProps) => {
   const props = withDefaultGetters(propsComponent);
   const {
     items,
@@ -205,7 +201,3 @@ const ContextMenuLevelsRender = (
     </TransitionGroup>
   );
 };
-
-export const ContextMenuLevels = React.forwardRef(
-  ContextMenuLevelsRender,
-) as ContextMenuLevelsComponent;


### PR DESCRIPTION
closes #4029. Удалил не используемый ref в `ContextMenuLevels`, оставшийся после фикса в #4006. Локально проверил вроде как ошибок в компонентах, включая `Breadcrumbs` из ишью больше не падает.

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
