### PR TITLE
docs(Badge): add missing `view=tinted` docs

### DIFF
--- a/src/components/Badge/__stand__/Badge.dev.stand.mdx
+++ b/src/components/Badge/__stand__/Badge.dev.stand.mdx
@@ -44,24 +44,24 @@ import { Badge } from '@consta/uikit/Badge';
 
 ```tsx
 type BadgePropStatus = 'success' | 'alert' | 'warning' | 'normal' | 'system';
-type BadgePropView = 'filled' | 'stroked';
-type BadgePropSize = 's' | 'm' | 'l';
+type BadgePropView = 'filled' | 'stroked' | 'tinted';
+type BadgePropSize = 'xs' | 's' | 'm' | 'l';
 type BadgePropForm = 'default' | 'round';
 ```
 
-| Свойство                           | Тип                                                         | По умолчанию | Описание                                   |
-| ---------------------------------- | ----------------------------------------------------------- | ------------ | ------------------------------------------ |
-| [`label?`](#бейджик-с-текстом)     | `string`                                                    | -            | Текст на бейджике                          |
-| [`minified?`](#бейджик-без-текста) | `boolean`                                                   | -            | Отображает бейджик без текста в виде точки |
-| [`iconLeft?`](#бейджик-с-иконкой)  | `IconComponent`                                             | -            | Иконка слева от текста                     |
-| [`iconRight?`](#бейджик-с-иконкой) | `IconComponent`                                             | -            | Иконка справа от текста                    |
-| [`size?`](#размер)                 | `'s' \| 'm' \| 'l'`                                         | `'m'`        | Размер бейджика                            |
-| [`view?`](#типы-бейджиков)         | `'filled' \| 'stroked'`                                     | `'filled'`   | Тип бейджика (заполненный или с обводкой)  |
-| [`status?`](#статус)               | `'success' \| 'alert' \| 'warning' \| 'normal' \| 'system'` | `'normal'`   | Статус бейджика                            |
-| [`form?`](#форма)                  | `'default' \| 'round'`                                      | `'default'`  | Форма бейджика                             |
-| `as?`                              | `keyof JSX.IntrinsicElements`                               | `'div'`      | HTML-тег для рендера компонента            |
-| `className?`                       | `string`                                                    | -            | Дополнительный CSS-класс                   |
-| `ref?`                             | `React.Ref<HTMLElement>`                                    | -            | Ссылка на корневой DOM-элемент             |
+| Свойство                           | Тип                                                         | По умолчанию | Описание                                                  |
+| ---------------------------------- | ----------------------------------------------------------- | ------------ | --------------------------------------------------------- |
+| [`label?`](#бейджик-с-текстом)     | `string`                                                    | -            | Текст на бейджике                                         |
+| [`minified?`](#бейджик-без-текста) | `boolean`                                                   | -            | Отображает бейджик без текста в виде точки                |
+| [`iconLeft?`](#бейджик-с-иконкой)  | `IconComponent`                                             | -            | Иконка слева от текста                                    |
+| [`iconRight?`](#бейджик-с-иконкой) | `IconComponent`                                             | -            | Иконка справа от текста                                   |
+| [`size?`](#размер)                 | `'xs' \| 's' \| 'm' \| 'l'`                                 | `'m'`        | Размер бейджика                                           |
+| [`view?`](#типы-бейджиков)         | `'filled' \| 'stroked' \| 'tinted'`                         | `'filled'`   | Тип бейджика (заполненный, с обводкой или полупрозрачный) |
+| [`status?`](#статус)               | `'success' \| 'alert' \| 'warning' \| 'normal' \| 'system'` | `'normal'`   | Статус бейджика                                           |
+| [`form?`](#форма)                  | `'default' \| 'round'`                                      | `'default'`  | Форма бейджика                                            |
+| `as?`                              | `keyof JSX.IntrinsicElements`                               | `'div'`      | HTML-тег для рендера компонента                           |
+| `className?`                       | `string`                                                    | -            | Дополнительный CSS-класс                                  |
+| `ref?`                             | `React.Ref<HTMLElement>`                                    | -            | Ссылка на корневой DOM-элемент                            |
 
 ## Содержимое
 
@@ -151,7 +151,7 @@ const BadgeExampleIcon = () => {
 
 ### Размер
 
-Свойство `size` задаёт размер бейджика. Возможные значения: `s`, `m` (по умолчанию), `l`.
+Свойство `size` задаёт размер бейджика. Возможные значения: `xs`, `s`, `m` (по умолчанию), `l`.
 
 <MdxTabs>
 
@@ -180,6 +180,7 @@ const BadgeExampleSize = () => {
 
 - `filled` — заполненный фон, для акцента на статусе.
 - `stroked` — с обводкой, менее заметный.
+- `tinted` — полупрозрачный фон.
 
 <MdxTabs>
 
@@ -194,6 +195,7 @@ const BadgeExampleView = () => {
     <>
       <Badge view="filled" label="Filled badge" />
       <Badge view="stroked" label="Stroked badge" />
+      <Badge view="tinted" label="Tinted badge" />
     </>
   );
 };

--- a/src/components/Badge/__stand__/examples/BadgeExampleView/BadgeExampleView.tsx
+++ b/src/components/Badge/__stand__/examples/BadgeExampleView/BadgeExampleView.tsx
@@ -7,5 +7,6 @@ export const BadgeExampleView = () => (
   <Example>
     <Badge view="filled" label="Filled badge" />
     <Badge view="stroked" label="Stroked badge" />
+    <Badge view="tinted" label="Tinted badge" />
   </Example>
 );


### PR DESCRIPTION
## Описание изменений
Случайно нашел что в `Badge` не было документации `для view='tinted'` и `size='xs'`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
