### PR TITLE
fix(Sidebar): fix bugged animation when input with autofocus is used inside sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -5,7 +5,9 @@
   left: 0;
   bottom: 0;
   display: flex;
-  overflow: hidden;
+
+  /* https://github.com/consta-design-system/uikit/issues/4118 */
+  overflow: clip;
   box-sizing: border-box;
 
   &:not(.Sidebar_hasOverlay) {


### PR DESCRIPTION
## Описание изменений
closes #4118

Проверял локально, не уверен, что на такое реально написать тест. Проверил во всех `position` и `size` пропсах, если есть еще идеи что протестить, могу посмотреть.

Также `overflow: clip` только с chrome 90 (2021 год), не знаю какие браузеры таргетит конста (нет browserslist, в babel не прописан targets.) возможно стоит оставить фолбэк на `overflow: hidden`

До фикса

https://github.com/user-attachments/assets/ebd81a5b-1469-4ba0-a472-f2ce29624949


После

https://github.com/user-attachments/assets/9d1f512d-1549-4092-bea2-2d7767c4af88


## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
